### PR TITLE
Add missing translations to library/functions.po

### DIFF
--- a/library/functions.po
+++ b/library/functions.po
@@ -491,6 +491,10 @@ msgid ""
 "integer *i*.  For example, ``chr(97)`` returns the string ``'a'``, while "
 "``chr(8364)`` returns the string ``'€'``. This is the inverse of :func:`ord`."
 msgstr ""
+"Retourne la chaîne représentant un caractère dont le code de caractère "
+"Unicode est le nombre entier *i*. Par exemple, ``chr(97)`` retourne la "
+"chaîne de caractères ``'a'``, tandis que ``chr(8364)`` retourne ``'€'``. Il "
+"s'agit de l'inverse de :func:`ord`."
 
 #: ../Doc/library/functions.rst:163
 msgid ""
@@ -683,6 +687,8 @@ msgid ""
 "Previously, :exc:`TypeError` was raised when null bytes were encountered in "
 "*source*."
 msgstr ""
+"Précédemment, l'exception :exc:`TypeError` était levée quand un caractère "
+"nul était rencontré dans *source*."
 
 #: ../Doc/library/functions.rst:256
 msgid ""
@@ -723,6 +729,8 @@ msgstr "Le type complexe est décrit dans :ref:`typesnumeric`."
 #: ../Doc/library/functions.rst:711
 msgid "Grouping digits with underscores as in code literals is allowed."
 msgstr ""
+"Les chiffres peuvent être groupés avec des tirets bas comme dans les "
+"expressions littérales."
 
 #: ../Doc/library/functions.rst:280
 msgid ""
@@ -783,6 +791,11 @@ msgid ""
 "complete, and may be inaccurate when the object has a custom :func:"
 "`__getattr__`."
 msgstr ""
+"Si l'objet ne fournit pas de méthode :meth:`__dir__`, la fonction fait de "
+"son mieux en rassemblant les informations de l'attribut :attr:`~object."
+"__dict__` de l'objet, si défini, et depuis son type. La liste résultante "
+"n'est pas nécessairement complète, et peut être inadaptée quand l'objet a "
+"un :func:`__getattr__` personnalisé."
 
 #: ../Doc/library/functions.rst:314
 msgid ""
@@ -1675,6 +1688,11 @@ msgid ""
 "given, it is closed when the returned I/O object is closed, unless *closefd* "
 "is set to ``False``.)"
 msgstr ""
+"*file* est un :term:`path-like object` donnant le chemin (absolu ou relatif "
+"au répertoire courant) du fichier à ouvrir ou un nombre entier représentant "
+"le descripteur de fichier à envelopper.  (Si un descripteur de fichier est "
+"donné, il sera fermé en même temps que l'objet *I/O* retourné, sauf si "
+"*closefd* est mis à ``False``.)"
 
 #: ../Doc/library/functions.rst:897
 msgid ""
@@ -2065,21 +2083,25 @@ msgstr ""
 
 #: ../Doc/library/functions.rst:1071
 msgid "The *opener* parameter was added."
-msgstr ""
+msgstr "Le paramètre *opener* a été ajouté."
 
 #: ../Doc/library/functions.rst:1072
 msgid "The ``'x'`` mode was added."
-msgstr ""
+msgstr "Le mode ``'x'`` a été ajouté."
 
 #: ../Doc/library/functions.rst:1073
 msgid ":exc:`IOError` used to be raised, it is now an alias of :exc:`OSError`."
 msgstr ""
+":exc:`IOError` était normalement levée, elle est maintenant un alias de :exc:"
+"`OSError`."
 
 #: ../Doc/library/functions.rst:1074
 msgid ""
 ":exc:`FileExistsError` is now raised if the file opened in exclusive "
 "creation mode (``'x'``) already exists."
 msgstr ""
+":exc:`FileExistsError` est maintenant levée si le fichier ouvert en mode "
+"création exclusive (``'x'``) existe déjà."
 
 #: ../Doc/library/functions.rst:1080
 msgid "The file is now non-inheritable."
@@ -2089,6 +2111,7 @@ msgstr "Il n'est plus possible d'hériter de *file*."
 msgid ""
 "Deprecated since version 3.4, will be removed in version 4.0: The 'U' mode."
 msgstr ""
+"Déprécié depuis la version 3.4, sera supprimé dans la 4.0 : Le mode 'U'."
 
 #: ../Doc/library/functions.rst:1084
 msgid "The ``'U'`` mode."
@@ -2106,17 +2129,19 @@ msgstr ""
 
 #: ../Doc/library/functions.rst:1092
 msgid "The ``'namereplace'`` error handler was added."
-msgstr ""
+msgstr "Le gestionnaire d'erreurs ``'namereplace'`` a été ajouté."
 
 #: ../Doc/library/functions.rst:1097
 msgid "Support added to accept objects implementing :class:`os.PathLike`."
-msgstr ""
+msgstr "Ajout du support des objets implémentant :class:`os.PathLike`."
 
 #: ../Doc/library/functions.rst:1098
 msgid ""
 "On Windows, opening a console buffer may return a subclass of :class:`io."
 "RawIOBase` other than :class:`io.FileIO`."
 msgstr ""
+"Sous Windows, ouvrir un *buffer* du terminal peut retourner une sous-classe "
+"de :class:`io.RawIOBase` autre que :class:`io.FileIO`."
 
 #: ../Doc/library/functions.rst:1103
 msgid ""
@@ -2125,6 +2150,10 @@ msgid ""
 "``ord('a')`` returns the integer ``97`` and ``ord('€')`` (Euro sign) returns "
 "``8364``.  This is the inverse of :func:`chr`."
 msgstr ""
+"Retourne le nombre entier représentant le code Unicode du caractère "
+"représenté par la chaîne donnée.  Par exemple, ``ord('a')`` retourne le "
+"nombre entier ``97`` et ``ord('€')`` (symbole Euro) retourne ``8364``. Il "
+"s'agit de l'inverse de :func:`chr`."
 
 #: ../Doc/library/functions.rst:1111
 msgid ""
@@ -2200,7 +2229,7 @@ msgid ""
 "Whether output is buffered is usually determined by *file*, but if the "
 "*flush* keyword argument is true, the stream is forcibly flushed."
 msgstr ""
-"Que la sortie utilise un buffer ou non est souvent décidé par *file*, mais "
+"Que la sortie utilise un *buffer* ou non est souvent décidé par *file*, mais "
 "si l'argument *flush* est vrai, le tampon du flux est vidé explicitement."
 
 #: ../Doc/library/functions.rst:1145
@@ -2334,6 +2363,9 @@ msgid ""
 "*ndigits* is omitted or is ``None``, it returns the nearest integer to its "
 "input."
 msgstr ""
+"Retourne *number* arrondi avec une précision de *ndigits* chiffres après la "
+"virgule.  Si *ndigits* est omis ou est ``None``, l'entier le plus proche est "
+"retourné."
 
 #: ../Doc/library/functions.rst:1261
 #, fuzzy
@@ -2732,6 +2764,15 @@ msgid ""
 "the :attr:`~object.__dict__` attribute.  For example, the following two "
 "statements create identical :class:`type` objects:"
 msgstr ""
+"Avec trois arguments, retourne un nouveau type. C'est essentiellement une "
+"forme dynamique de l'instruction :keyword:`class`. La chaîne *name* est le "
+"nom de la classe et deviendra l'attribut :attr:`~definition.__name__` ; le "
+"*tuple* *bases* contient les classes mères et deviendra l'attribut :attr:"
+"`~class.__bases__` ; et le dictionnaire *dict* est l'espace de noms "
+"contenant les définitions du corps de la classe, il est copié vers un "
+"dictionnaire standard pour devenir l'attribut :attr:`~object.__dict__`.  Par "
+"exemple, les deux instructions suivantes créent deux instances identiques "
+"de :class:`type`."
 
 #: ../Doc/library/functions.rst:1486
 msgid "See also :ref:`bltin-type-objects`."
@@ -2742,12 +2783,18 @@ msgid ""
 "Subclasses of :class:`type` which don't override ``type.__new__`` may no "
 "longer use the one-argument form to get the type of an object."
 msgstr ""
+"Les sous-classes de :class:`type` qui ne redéfinissent pas ``type.__new__`` "
+"ne devraient plus utiliser la forme à un argument pour récupérer le type "
+"d'un objet."
 
 #: ../Doc/library/functions.rst:1494
 msgid ""
 "Return the :attr:`~object.__dict__` attribute for a module, class, instance, "
 "or any other object with a :attr:`~object.__dict__` attribute."
 msgstr ""
+"Retourne l'attribut :attr:`~object.__dict__` d'un module, d'une classe, "
+"d'une instance ou de n'importe quel objet avec un attribut :attr:`~object."
+"__dict__`."
 
 #: ../Doc/library/functions.rst:1497
 msgid ""
@@ -2756,6 +2803,11 @@ msgid ""
 "their :attr:`~object.__dict__` attributes (for example, classes use a :class:"
 "`types.MappingProxyType` to prevent direct dictionary updates)."
 msgstr ""
+"Les objets tels que les modules et les instances on un attribut :attr:"
+"`~object.__dict__` modifiable ; Cependant, d'autres objets peuvent avoir des "
+"restrictions en écriture sur leurs attributs :attr:`~object.__dict__` (par "
+"exemple, les classes utilisent un  :class:`types.MappingProxyType` pour "
+"éviter les modifications directes du dictionnaire)."
 
 #: ../Doc/library/functions.rst:1502
 msgid ""


### PR DESCRIPTION
Salut,

Je me suis maintenant attaqué au fichier `library/functions.po` et ai complété les traductions manquantes.
Je vais voir aussi pour regarder celles qui sont marquées comme ambiguës.