### PR TITLE
Complete library/json.po

### DIFF
--- a/library/json.po
+++ b/library/json.po
@@ -19,11 +19,11 @@ msgstr ""
 
 #: ../Doc/library/json.rst:2
 msgid ":mod:`json` --- JSON encoder and decoder"
-msgstr ""
+msgstr ":mod:`json` --- Encodage et décodage JSON"
 
 #: ../Doc/library/json.rst:10
 msgid "**Source code:** :source:`Lib/json/__init__.py`"
-msgstr ""
+msgstr "**Code source :** :source:`Lib/json/__init__.py`"
 
 #: ../Doc/library/json.rst:14
 msgid ""
@@ -34,44 +34,55 @@ msgid ""
 "wiki/JavaScript>`_ object literal syntax (although it is not a strict subset "
 "of JavaScript [#rfc-errata]_ )."
 msgstr ""
+"`JSON (JavaScript Object Notation) <http://json.org>`_, spécifié par la :rfc:"
+"`7159` (qui rend la :rfc:`4627` obsolète) et par le standard `ECMA-404 "
+"<http://www.ecma-international.org/publications/standards/Ecma-404.htm>`_, "
+"est une interface légère d'échange de données inspirée par la syntaxe des "
+"objets littéraux `JavaScript <https://fr.wikipedia.org/wiki/JavaScript>`_ "
+"(bien que ce ne soit pas un sous-ensemble strict de Javascript [#rfc-"
+"errata]_ )."
 
 #: ../Doc/library/json.rst:21
 msgid ""
 ":mod:`json` exposes an API familiar to users of the standard library :mod:"
 "`marshal` and :mod:`pickle` modules."
 msgstr ""
+":mod:`json` expose une API familière aux utilisateurs des modules de la "
+"bibliothèque standard :mod:`marshal` et :mod:`pickle`."
 
 #: ../Doc/library/json.rst:24
 msgid "Encoding basic Python object hierarchies::"
-msgstr ""
+msgstr "Encodage d'objets Python basiques : ::"
 
 #: ../Doc/library/json.rst:43
 msgid "Compact encoding::"
-msgstr ""
+msgstr "Encodage compact : ::"
 
 #: ../Doc/library/json.rst:49
 msgid "Pretty printing::"
-msgstr ""
+msgstr "Affichage élégant : ::"
 
 #: ../Doc/library/json.rst:58
 msgid "Decoding JSON::"
-msgstr ""
+msgstr "Décodage JSON : ::"
 
 #: ../Doc/library/json.rst:70
 msgid "Specializing JSON object decoding::"
-msgstr ""
+msgstr "Spécialisation du décodage JSON pour un objet : ::"
 
 #: ../Doc/library/json.rst:85
 msgid "Extending :class:`JSONEncoder`::"
-msgstr ""
+msgstr "Étendre la classe :class:`JSONEncoder` : ::"
 
 #: ../Doc/library/json.rst:105
 msgid "Using :mod:`json.tool` from the shell to validate and pretty-print::"
 msgstr ""
+"Utiliser :mod:`json.tool` depuis le *shell* pour valider et afficher "
+"élégamment : ::"
 
 #: ../Doc/library/json.rst:114
 msgid "See :ref:`json-commandline` for detailed documentation."
-msgstr ""
+msgstr "Voir :ref:`json-commandline` pour une documentation détaillée."
 
 #: ../Doc/library/json.rst:120
 msgid ""
@@ -80,6 +91,10 @@ msgid ""
 "value) is also a subset of YAML 1.0 and 1.1.  This module can thus also be "
 "used as a YAML serializer."
 msgstr ""
+"JSON est un sous-ensemble de `YAML <http://yaml.org/>`_ 1.2.  Le JSON "
+"produit par les paramètres par défaut de ce module (en particulier, la "
+"valeur par défaut de *separators*) est aussi un sous ensemble de YAML 1.0 et "
+"1.1.  Ce module peut alors aussi être utilisé comme sérialiseur YAML."
 
 #: ../Doc/library/json.rst:127
 msgid "Basic Usage"
@@ -91,6 +106,9 @@ msgid ""
 "supporting :term:`file-like object`) using this :ref:`conversion table <py-"
 "to-json-table>`."
 msgstr ""
+"Sérialise *obj* comme un flux JSON formaté vers *fp* (un :term:`file-like "
+"object` supportant ``.write()``) utilisant cette :ref:`table de conversion "
+"<py-to-json-table>`."
 
 #: ../Doc/library/json.rst:138
 msgid ""
@@ -98,12 +116,19 @@ msgid ""
 "basic type (:class:`str`, :class:`int`, :class:`float`, :class:`bool`, "
 "``None``) will be skipped instead of raising a :exc:`TypeError`."
 msgstr ""
+"Si *skipkeys* est vrai (faux par défaut), alors les clefs de dictionnaires "
+"qui ne sont pas de types basiques (:class:`str`, :class:`int`, :class:"
+"`float`, :class:`bool`, ``None``) seront ignorées, elles provoquent "
+"normalement la levée d'une :exc:`TypeError`."
 
 #: ../Doc/library/json.rst:142
 msgid ""
 "The :mod:`json` module always produces :class:`str` objects, not :class:"
 "`bytes` objects. Therefore, ``fp.write()`` must support :class:`str` input."
 msgstr ""
+"Le module :mod:`json` produit toujours des objets :class:`str`, et non des "
+"objets :class:`bytes`. ``fp.write()`` doit ainsi supporter un objet :class:"
+"`str` en entrée."
 
 #: ../Doc/library/json.rst:146 ../Doc/library/json.rst:419
 msgid ""
@@ -111,6 +136,9 @@ msgid ""
 "all incoming non-ASCII characters escaped.  If *ensure_ascii* is false, "
 "these characters will be output as-is."
 msgstr ""
+"Si *ensure_ascii* est vrai (par défaut), il est garanti que les caractères "
+"non-ASCII soient tous échappés sur la sortie.  Si *ensure_ascii* est faux, "
+"ces caractères seront écrits comme tels."
 
 #: ../Doc/library/json.rst:150
 msgid ""
@@ -118,6 +146,9 @@ msgid ""
 "reference check for container types will be skipped and a circular reference "
 "will result in an :exc:`OverflowError` (or worse)."
 msgstr ""
+"Si *check_circular* est faux (vrai par défaut), la vérification des "
+"références circulaires pour les conteneurs sera ignorée, et une référence "
+"circulaire résultera en une :exc:`OverflowError` (ou pire)."
 
 #: ../Doc/library/json.rst:154
 msgid ""
@@ -127,6 +158,11 @@ msgid ""
 "*allow_nan* is true, their JavaScript equivalents (``NaN``, ``Infinity``, ``-"
 "Infinity``) will be used."
 msgstr ""
+"Si *allow_nan* est faux (vrai par défaut), une :exc:`ValueError` sera levée "
+"lors de la sérialisation de valeurs :class:`float` extérieures aux bornes "
+"(``nan``, ``inf``, ``-inf``), en respect strict de la spécification JSON. Si "
+"*allow_nan* est vrai, leurs équivalents JavaScript (``NaN``, ``Infinity``, "
+"``-Infinity``) seront utilisés."
 
 #: ../Doc/library/json.rst:160 ../Doc/library/json.rst:438
 msgid ""
@@ -137,10 +173,18 @@ msgid ""
 "indent indents that many spaces per level.  If *indent* is a string (such as "
 "``\"\\t\"``), that string is used to indent each level."
 msgstr ""
+"Si *indent* est un nombre entier positif ou une chaîne de caractères, les "
+"éléments de tableaux et les membres d'objets JSON seront affichés élégamment "
+"avec ce niveau d'indentation.  Un niveau d'indentation de 0, négatif, ou ``"
+"\"\"`` n'insérera que des retours à la ligne.  ``None`` (la valeur par "
+"défaut) choisit la représentation la plus compacte. Utiliser un entier "
+"positif comme indentation indente d'autant d'espaces par niveau.  Si "
+"*indent* est une chaîne (telle que ``\"\\t\"``), cette chaîne est utilisée "
+"pour indenter à chaque niveau."
 
 #: ../Doc/library/json.rst:167 ../Doc/library/json.rst:445
 msgid "Allow strings for *indent* in addition to integers."
-msgstr ""
+msgstr "Autorise les chaînes en plus des nombres entiers pour *indent*."
 
 #: ../Doc/library/json.rst:170 ../Doc/library/json.rst:448
 msgid ""
@@ -149,10 +193,15 @@ msgid ""
 "': ')`` otherwise.  To get the most compact JSON representation, you should "
 "specify ``(',', ':')`` to eliminate whitespace."
 msgstr ""
+"Si spécifié, *separators* doit être un *tuple* ``(item_separator, "
+"key_separator)``.  Sa valeur par défaut est ``(', ', ': ')`` si *indent* est "
+"``None``, et ``(',', ': ')`` autrement.  Pour obtenir la représentation JSON "
+"la plus compacte possible, vous devriez spécifier ``(',', ':')`` pour "
+"éliminer les espacements."
 
 #: ../Doc/library/json.rst:175 ../Doc/library/json.rst:453
 msgid "Use ``(',', ': ')`` as default if *indent* is not ``None``."
-msgstr ""
+msgstr "Utilise ``(',', ': ')`` par défaut si *indent* n'est pas ``None``."
 
 #: ../Doc/library/json.rst:178 ../Doc/library/json.rst:456
 msgid ""
@@ -161,12 +210,19 @@ msgid ""
 "version of the object or raise a :exc:`TypeError`.  If not specified, :exc:"
 "`TypeError` is raised."
 msgstr ""
+"Si spécifié, *default* doit être une fonction qui sera appelée pour les "
+"objets qui ne peuvent être sérialisés autrement.  Elle doit renvoyer une "
+"représentation de l'objet encodable en JSON ou lever une :exc:`TypeError`.  "
+"Si non spécifié, une :exc:`TypeError` sera levée pour les types non-"
+"sérialisables."
 
 #: ../Doc/library/json.rst:183
 msgid ""
 "If *sort_keys* is true (default: ``False``), then the output of dictionaries "
 "will be sorted by key."
 msgstr ""
+"Si *sort_keys* est vrai (faux par défaut), les dictionnaires seront "
+"retranscrits triés selon leurs clés."
 
 #: ../Doc/library/json.rst:186
 msgid ""
@@ -174,11 +230,17 @@ msgid ""
 "meth:`default` method to serialize additional types), specify it with the "
 "*cls* kwarg; otherwise :class:`JSONEncoder` is used."
 msgstr ""
+"Pour utiliser une sous-classe :class:`JSONEncoder` personnalisée (p. ex. une "
+"qui redéfinit la méthode :meth:`default` pour sérialiser des types "
+"additionnels), spécifiez-la avec le paramètre nommé *cls* ; autrement, :"
+"class:`JSONEncoder` est utilisée."
 
 #: ../Doc/library/json.rst:190 ../Doc/library/json.rst:266
 msgid ""
 "All optional parameters are now :ref:`keyword-only <keyword-only_parameter>`."
 msgstr ""
+"Tous les paramètres optionnels sont maintenant des :ref:`keyword-only "
+"<keyword-only_parameter>`."
 
 #: ../Doc/library/json.rst:199
 msgid ""
@@ -186,6 +248,9 @@ msgid ""
 "table <py-to-json-table>`.  The arguments have the same meaning as in :func:"
 "`dump`."
 msgstr ""
+"Sérialise *obj* vers un JSON formaté :class:`str`, en utilisant cette :ref:"
+"`table de conversion <py-to-json-table>`.  Les arguments ont la même "
+"signification que ceux de :func:`dump`."
 
 #: ../Doc/library/json.rst:205
 msgid ""
@@ -193,6 +258,10 @@ msgid ""
 "trying to serialize multiple objects with repeated calls to :func:`dump` "
 "using the same *fp* will result in an invalid JSON file."
 msgstr ""
+"À l'inverse de :mod:`pickle` et :mod:`marshal`, JSON n'est pas un protocole "
+"par trames, donc essayer de sérialiser de multiples objets par des appels "
+"répétés à :func:`dump` en utilisant le même *fp* résultera en un fichier "
+"JSON invalide."
 
 #: ../Doc/library/json.rst:211
 msgid ""
@@ -202,6 +271,12 @@ msgid ""
 "JSON and then back into a dictionary, the dictionary may not equal the "
 "original one. That is, ``loads(dumps(x)) != x`` if x has non-string keys."
 msgstr ""
+"Les clés dans les couples JSON clé/valeur sont toujours de type :class:"
+"`str`. Quand un dictionnaire est converti en JSON, toutes les clés du "
+"dictionnaire sont transformées en chaînes de caractères. Ce qui fait que si "
+"un dictionnaire est converti en JSON et reconverti en dictionnaire, le "
+"résultat peut ne pas être égal à l'original. Ainsi, ``loads(dumps(x)) != x`` "
+"si x contient des clés qui ne sont pas des chaînes."
 
 #: ../Doc/library/json.rst:220
 msgid ""
@@ -209,6 +284,9 @@ msgid ""
 "containing a JSON document) to a Python object using this :ref:`conversion "
 "table <json-to-py-table>`."
 msgstr ""
+"Désérialise *fp* (un :term:`file-like object` supportant ``.read()``, "
+"contenant un document JSON) vers un objet Python en utilisant cette :ref:"
+"`table de conversion <json-to-py-table>`."
 
 #: ../Doc/library/json.rst:224
 msgid ""
@@ -218,6 +296,12 @@ msgid ""
 "be used to implement custom decoders (e.g. `JSON-RPC <http://www.jsonrpc."
 "org>`_ class hinting)."
 msgstr ""
+"*object_hook* est une fonction optionnelle qui sera appelée avec le résultat "
+"de chaque objet littéral décodé (chaque :class:`dict`).  La valeur de retour "
+"de *object_hook* sera utilisée à la place du :class:`dict`.  Cette "
+"fonctionnalité peut être utilisée pour implémenter des décodeurs "
+"personnalisés (p. ex. les *class hinting* de `JSON-RPC <http://www.jsonrpc."
+"org>`_)."
 
 #: ../Doc/library/json.rst:230
 msgid ""
@@ -229,10 +313,18 @@ msgid ""
 "`collections.OrderedDict` will remember the order of insertion). If "
 "*object_hook* is also defined, the *object_pairs_hook* takes priority."
 msgstr ""
+"*object_pairs_hook* est une fonction optionnelle qui sera appelé pour chaque "
+"objet littéral décodé, avec une liste ordonnée de couples.  La valeur de "
+"retour de *object_pairs_hook* sera utilisée à la place du :class:`dict`.  "
+"Cette fonctionnalité peut être utilisée pour implémenter des décodeurs "
+"personnalisés qui s'appuient sur l'ordre dans lequel les couples clé/valeur "
+"sont décodés (par exemple, :func:`collections.OrderedDict` mémorisera "
+"l'ordre d'insertion). *object_pairs_hook* prend la priorité sur "
+"*object_hook*, si cette dernière est aussi définie."
 
 #: ../Doc/library/json.rst:238 ../Doc/library/json.rst:333
 msgid "Added support for *object_pairs_hook*."
-msgstr ""
+msgstr "Ajout du support de *object_pairs_hook*."
 
 #: ../Doc/library/json.rst:241 ../Doc/library/json.rst:336
 msgid ""
@@ -241,6 +333,11 @@ msgid ""
 "This can be used to use another datatype or parser for JSON floats (e.g. :"
 "class:`decimal.Decimal`)."
 msgstr ""
+"*parse_float*, si spécifiée, sera appelée pour chaque nombre réel JSON à "
+"décoder sous forme d'une chaîne de caractères.  Par défaut, elle est "
+"équivalente à ``float(num_str)``. Cela peut servir à utiliser un autre type "
+"de données ou un autre analyseur pour les nombres réels JSON (p. ex. :class:"
+"`decimal.Decimal`)."
 
 #: ../Doc/library/json.rst:246 ../Doc/library/json.rst:341
 msgid ""
@@ -249,6 +346,11 @@ msgid ""
 "can be used to use another datatype or parser for JSON integers (e.g. :class:"
 "`float`)."
 msgstr ""
+"*parse_int*, si spécifiée, sera appelée pour chaque nombre entier JSON à "
+"décoder sous forme d'une chaîne de caractères.  Par défaut, elle est "
+"équivalente à ``int(num_str)``. Cela peut servir à utiliser un autre type de "
+"données ou un autre analyseur pour les nombres entiers JSON (p. ex. :class:"
+"`float`)."
 
 #: ../Doc/library/json.rst:251 ../Doc/library/json.rst:346
 msgid ""
@@ -256,10 +358,14 @@ msgid ""
 "strings: ``'-Infinity'``, ``'Infinity'``, ``'NaN'``. This can be used to "
 "raise an exception if invalid JSON numbers are encountered."
 msgstr ""
+"*parse_constant*, si spécifiée, sera appelée avec l'une des chaînes de "
+"caractères suivantes : ``'-Infinity'``, ``'Infinity'`` ou ``'NaN'``.  Cela "
+"peut servir à lever une exception si des nombres JSON invalides sont "
+"rencontrés."
 
 #: ../Doc/library/json.rst:256
 msgid "*parse_constant* doesn't get called on 'null', 'true', 'false' anymore."
-msgstr ""
+msgstr "*parse_constant* n'est plus appelée pour 'null', 'true' ou 'false'."
 
 #: ../Doc/library/json.rst:259
 msgid ""
@@ -267,6 +373,10 @@ msgid ""
 "kwarg; otherwise :class:`JSONDecoder` is used.  Additional keyword arguments "
 "will be passed to the constructor of the class."
 msgstr ""
+"Pour utiliser une sous-classe :class:`JSONDecoder` personnalisée, spécifiez-"
+"la avec l'argument nommé ``cls`` ; autrement, :class:`JSONDecoder` est "
+"utilisée.  Les arguments nommés additionnels seront passés au constructeur "
+"de cette classe."
 
 #: ../Doc/library/json.rst:263 ../Doc/library/json.rst:278
 #: ../Doc/library/json.rst:356
@@ -274,6 +384,8 @@ msgid ""
 "If the data being deserialized is not a valid JSON document, a :exc:"
 "`JSONDecodeError` will be raised."
 msgstr ""
+"Si les données à désérialiser ne sont pas un document JSON valide, une :exc:"
+"`JSONDecodeError` sera levée."
 
 #: ../Doc/library/json.rst:271
 msgid ""
@@ -281,30 +393,37 @@ msgid ""
 "instance containing a JSON document) to a Python object using this :ref:"
 "`conversion table <json-to-py-table>`."
 msgstr ""
+"Désérialise *s* (une instance de :class:`str`, :class:`bytes` ou :class:"
+"`bytearray` contenant un document JSON) vers un objet Python en utilisant "
+"cette :ref:`table de conversion <json-to-py-table>`."
 
 #: ../Doc/library/json.rst:275
 msgid ""
 "The other arguments have the same meaning as in :func:`load`, except "
 "*encoding* which is ignored and deprecated."
 msgstr ""
+"Les autres arguments ont la même signification que pour :func:`load`, à "
+"l'exception d'*encoding* qui est ignoré et déprécié."
 
 #: ../Doc/library/json.rst:281
 msgid ""
 "*s* can now be of type :class:`bytes` or :class:`bytearray`. The input "
 "encoding should be UTF-8, UTF-16 or UTF-32."
 msgstr ""
+"*s* peut maintenant être de type :class:`bytes` ou :class:`bytearray`."
+"L'encodage d'entrée doit être UTF-8, UTF-16 ou UTF-32."
 
 #: ../Doc/library/json.rst:287
 msgid "Encoders and Decoders"
-msgstr ""
+msgstr "Encodeurs et décodeurs"
 
 #: ../Doc/library/json.rst:291
 msgid "Simple JSON decoder."
-msgstr ""
+msgstr "Décodeur simple JSON."
 
 #: ../Doc/library/json.rst:293
 msgid "Performs the following translations in decoding by default:"
-msgstr ""
+msgstr "Applique par défaut les conversions suivantes en décodant :"
 
 #: ../Doc/library/json.rst:298 ../Doc/library/json.rst:389
 msgid "JSON"
@@ -320,59 +439,59 @@ msgstr "objet"
 
 #: ../Doc/library/json.rst:300 ../Doc/library/json.rst:391
 msgid "dict"
-msgstr "dict"
+msgstr "*dict*"
 
 #: ../Doc/library/json.rst:302 ../Doc/library/json.rst:393
 msgid "array"
-msgstr "array"
+msgstr "*array*"
 
 #: ../Doc/library/json.rst:302
 msgid "list"
-msgstr "list"
+msgstr "*list*"
 
 #: ../Doc/library/json.rst:304 ../Doc/library/json.rst:395
 msgid "string"
-msgstr "string"
+msgstr "*string*"
 
 #: ../Doc/library/json.rst:304 ../Doc/library/json.rst:395
 msgid "str"
-msgstr "str"
+msgstr "*str*"
 
 #: ../Doc/library/json.rst:306
 msgid "number (int)"
-msgstr ""
+msgstr "*number* (nombre entier)"
 
 #: ../Doc/library/json.rst:306
 msgid "int"
-msgstr "int"
+msgstr "*int*"
 
 #: ../Doc/library/json.rst:308
 msgid "number (real)"
-msgstr ""
+msgstr "*number* (nombre réel)"
 
 #: ../Doc/library/json.rst:308
 msgid "float"
-msgstr "float"
+msgstr "*float*"
 
 #: ../Doc/library/json.rst:310 ../Doc/library/json.rst:399
 msgid "true"
-msgstr ""
+msgstr "*true*"
 
 #: ../Doc/library/json.rst:310 ../Doc/library/json.rst:399
 msgid "True"
-msgstr ""
+msgstr "*True*"
 
 #: ../Doc/library/json.rst:312 ../Doc/library/json.rst:401
 msgid "false"
-msgstr ""
+msgstr "*false*"
 
 #: ../Doc/library/json.rst:312 ../Doc/library/json.rst:401
 msgid "False"
-msgstr ""
+msgstr "*False*"
 
 #: ../Doc/library/json.rst:314 ../Doc/library/json.rst:403
 msgid "null"
-msgstr ""
+msgstr "*null*"
 
 #: ../Doc/library/json.rst:314 ../Doc/library/json.rst:403
 msgid "None"
@@ -383,6 +502,9 @@ msgid ""
 "It also understands ``NaN``, ``Infinity``, and ``-Infinity`` as their "
 "corresponding ``float`` values, which is outside the JSON spec."
 msgstr ""
+"Les valeurs ``NaN``, ``Infinity`` et ``-Infinity`` sont aussi comprises "
+"comme leurs valeurs ``float`` correspondantes, bien que ne faisant pas "
+"partie de la spécification JSON."
 
 #: ../Doc/library/json.rst:320
 msgid ""
@@ -391,6 +513,10 @@ msgid ""
 "class:`dict`.  This can be used to provide custom deserializations (e.g. to "
 "support JSON-RPC class hinting)."
 msgstr ""
+"*object_hook*, si spécifiée, sera appelée avec le résultat de chaque objet "
+"JSON décodé et sa valeur de retour sera utilisée à la place du :class:`dict` "
+"donné.  Cela peut être utilisé pour apporter des désérialisations "
+"personnalisées (p. ex. pour supporter les *class hinting* de JSON-RPC)."
 
 #: ../Doc/library/json.rst:325
 msgid ""
@@ -402,6 +528,14 @@ msgid ""
 "will remember the order of insertion). If *object_hook* is also defined, the "
 "*object_pairs_hook* takes priority."
 msgstr ""
+"*object_pairs_hook*, si spécifiée, sera appelée avec le résultat de chaque "
+"objet JSON décodé avec une liste ordonnée de couples.  Sa valeur de retour "
+"sera utilisée à la place du :class:`dict`.  Cette fonctionnalité peut être "
+"utilisée pour implémenter des décodeurs personnalisés se basant sur l'ordre "
+"dans lequel les couples clé/valeur sont décodés (par exemple, :func:"
+"`collections.OrderedDict` mémorisera l'ordre d'insertion). "
+"*object_pairs_hook* prend la priorité sur *object_hook*, si cette dernière "
+"est aussi définie."
 
 #: ../Doc/library/json.rst:351
 msgid ""
@@ -410,22 +544,32 @@ msgid ""
 "with character codes in the 0--31 range, including ``'\\t'`` (tab), "
 "``'\\n'``, ``'\\r'`` and ``'\\0'``."
 msgstr ""
+"Si *strict* est faux (``True`` par défaut), alors les caractères de contrôle "
+"seront autorisés à l'intérieur des chaînes.  Les caractères de contrôle dans "
+"ce contexte sont ceux dont les codes sont dans l'intervalle 0--31, incluant "
+"``'\\t'`` (tab), ``'\\n'``, ``'\\r'`` et ``'\\0'``."
 
 #: ../Doc/library/json.rst:359 ../Doc/library/json.rst:461
 msgid "All parameters are now :ref:`keyword-only <keyword-only_parameter>`."
 msgstr ""
+"Tous les paramètres sont maintenant des :ref:`keyword-only <keyword-"
+"only_parameter>`."
 
 #: ../Doc/library/json.rst:364
 msgid ""
 "Return the Python representation of *s* (a :class:`str` instance containing "
 "a JSON document)."
 msgstr ""
+"Renvoie la représentation Python de *s* (une instance :class:`str` contenant "
+"un document JSON)."
 
 #: ../Doc/library/json.rst:367
 msgid ""
 ":exc:`JSONDecodeError` will be raised if the given JSON document is not "
 "valid."
 msgstr ""
+"Une :exc:`JSONDecodeError` sera levée si le document JSON donné n'est pas "
+"valide."
 
 #: ../Doc/library/json.rst:372
 msgid ""
@@ -433,36 +577,42 @@ msgid ""
 "document) and return a 2-tuple of the Python representation and the index in "
 "*s* where the document ended."
 msgstr ""
+"Décode en document JSON depuis *s* (une instance :class:`str` débutant par "
+"un document JSON) et renvoie un *tuple* de 2 éléments contenant la "
+"représentation Python de l'objet et l'index dans *s* où le document se "
+"terminait."
 
 #: ../Doc/library/json.rst:376
 msgid ""
 "This can be used to decode a JSON document from a string that may have "
 "extraneous data at the end."
 msgstr ""
+"Elle peut être utilisée pour décoder un document JSON depuis une chaîne qui "
+"peut contenir des données supplémentaires à la fin."
 
 #: ../Doc/library/json.rst:382
 msgid "Extensible JSON encoder for Python data structures."
-msgstr ""
+msgstr "Encodeur JSON extensible pour les structures de données Python."
 
 #: ../Doc/library/json.rst:384
 msgid "Supports the following objects and types by default:"
-msgstr ""
+msgstr "Supporte par défaut les objets et types suivants :"
 
 #: ../Doc/library/json.rst:393
 msgid "list, tuple"
-msgstr ""
+msgstr "*list*, *tuple*"
 
 #: ../Doc/library/json.rst:397
 msgid "int, float, int- & float-derived Enums"
-msgstr ""
+msgstr "*int*, *float*, et *Enums* dérivées d'*int* ou de *float*"
 
 #: ../Doc/library/json.rst:397
 msgid "number"
-msgstr ""
+msgstr "*number*"
 
 #: ../Doc/library/json.rst:406
 msgid "Added support for int- and float-derived Enum classes."
-msgstr ""
+msgstr "Ajout du support des classes *Enum* dérivées d'*int* ou de *float*"
 
 #: ../Doc/library/json.rst:409
 msgid ""
@@ -471,6 +621,10 @@ msgid ""
 "``o`` if possible, otherwise it should call the superclass implementation "
 "(to raise :exc:`TypeError`)."
 msgstr ""
+"Pour l'étendre afin de reconnaître d'autres types d'objets, il suffit d'en "
+"créer une sous-classe et d'implémenter une nouvelle méthode :meth:`default` "
+"qui renverrait si possible un objet sérialisable pour ``o``, ou ferait appel "
+"à l'implémentation de la classe mère (qui lèverait une :exc:`TypeError`)."
 
 #: ../Doc/library/json.rst:414
 msgid ""
@@ -478,6 +632,10 @@ msgid ""
 "attempt encoding of keys that are not :class:`str`, :class:`int`, :class:"
 "`float` or ``None``.  If *skipkeys* is true, such items are simply skipped."
 msgstr ""
+"Si *skipkeys* est faux (par défaut), une :exc:`TypeError` sera levée lors de "
+"l'encodage de clés autres que des :class:`str`, des :class:`int`, des :class:"
+"`float` ou ``None``.  Si *skipkeys* est vrai, ces éléments sont simplement "
+"ignorés."
 
 #: ../Doc/library/json.rst:423
 msgid ""
@@ -486,6 +644,10 @@ msgid ""
 "prevent an infinite recursion (which would cause an :exc:`OverflowError`). "
 "Otherwise, no such check takes place."
 msgstr ""
+"Si *check_circular* est vrai (par défaut), une vérification aura lieu sur "
+"les listes, dictionnaires et objets personnalisés, afin de détecter les "
+"références circulaires et éviter les récursions infinies (qui causeraient "
+"une :exc:`OverflowError`). Autrement, la vérification n'a pas lieu."
 
 #: ../Doc/library/json.rst:428
 msgid ""
@@ -494,6 +656,11 @@ msgid ""
 "compliant, but is consistent with most JavaScript based encoders and "
 "decoders.  Otherwise, it will be a :exc:`ValueError` to encode such floats."
 msgstr ""
+"Si *allow_nan* est vrai (par défaut), alors ``NaN``, ``Infinity`` et ``-"
+"Infinity`` seront encodés comme tels.  Ce comportement ne respecte pas la "
+"spécification JSON, mais est cohérent avec le majorité des encodeurs/"
+"décodeurs JavaScript.  Autrement, une :exc:`ValueError` sera levée pour de "
+"telles valeurs."
 
 #: ../Doc/library/json.rst:434
 msgid ""
@@ -501,6 +668,9 @@ msgid ""
 "will be sorted by key; this is useful for regression tests to ensure that "
 "JSON serializations can be compared on a day-to-day basis."
 msgstr ""
+"Si *sort_keys* est vrai (``False`` par défaut), alors les dictionnaires "
+"seront triés par clés en sortie ; cela est utile lors de tests de régression "
+"pour pouvoir comparer les sérialisations JSON au jour le jour."
 
 #: ../Doc/library/json.rst:467
 msgid ""
@@ -508,24 +678,33 @@ msgid ""
 "object for *o*, or calls the base implementation (to raise a :exc:"
 "`TypeError`)."
 msgstr ""
+"Implémentez cette méthode dans une sous-classe afin qu'elle renvoie un objet "
+"sérialisable pour *o*, ou appelle l'implémentation de base (qui lèvera une :"
+"exc:`TypeError`)."
 
 #: ../Doc/library/json.rst:471
 msgid ""
 "For example, to support arbitrary iterators, you could implement default "
 "like this::"
 msgstr ""
+"Par exemple, pour supporter des itérateurs arbitraires, vous pourriez "
+"implémenter *default* comme cela : ::"
 
 #: ../Doc/library/json.rst:487
 msgid ""
 "Return a JSON string representation of a Python data structure, *o*.  For "
 "example::"
 msgstr ""
+"Renvoie une chaîne JSON représentant la structure de données Python *o*.  "
+"Par exemple : ::"
 
 #: ../Doc/library/json.rst:496
 msgid ""
 "Encode the given object, *o*, and yield each string representation as "
 "available.  For example::"
 msgstr ""
+"Encode l'objet *o* donné, et produit chaque chaîne représentant l'objet "
+"selon disponibilité.  Par exemple : ::"
 
 #: ../Doc/library/json.rst:504
 msgid "Exceptions"
@@ -534,30 +713,31 @@ msgstr "Les exceptions"
 #: ../Doc/library/json.rst:508
 msgid "Subclass of :exc:`ValueError` with the following additional attributes:"
 msgstr ""
+"Sous-classe de :exc:`ValueError` avec les attributs additionnels suivants :"
 
 #: ../Doc/library/json.rst:512
 msgid "The unformatted error message."
-msgstr "Le message d'erreur non formatté."
+msgstr "Le message d'erreur non formaté."
 
 #: ../Doc/library/json.rst:516
 msgid "The JSON document being parsed."
-msgstr ""
+msgstr "Le document JSON actuellement traité."
 
 #: ../Doc/library/json.rst:520
 msgid "The start index of *doc* where parsing failed."
-msgstr ""
+msgstr "L'index de *doc* à partir duquel l'analyse a échoué."
 
 #: ../Doc/library/json.rst:524
 msgid "The line corresponding to *pos*."
-msgstr ""
+msgstr "La ligne correspondant à *pos*."
 
 #: ../Doc/library/json.rst:528
 msgid "The column corresponding to *pos*."
-msgstr ""
+msgstr "La colonne correspondant à *pos*."
 
 #: ../Doc/library/json.rst:534
 msgid "Standard Compliance and Interoperability"
-msgstr ""
+msgstr "Conformité au standard et Interopérabilité"
 
 #: ../Doc/library/json.rst:536
 msgid ""
@@ -567,22 +747,32 @@ msgid ""
 "class:`JSONEncoder` and :class:`JSONDecoder` subclasses, and parameters "
 "other than those explicitly mentioned, are not considered."
 msgstr ""
+"Le format JSON est spécifié par la :rfc:`7159` et le standard `ECMA-404 "
+"<http://www.ecma-international.org/publications/standards/Ecma-404.htm>`_. "
+"Cette section détaille la conformité à la RFC au niveau du module. Pour "
+"faire simple, les sous-classes de :class:`JSONEncoder` et :class:"
+"`JSONDecoder`, et les paramètres autres que ceux explicitement mentionnés ne "
+"sont pas considérés."
 
 #: ../Doc/library/json.rst:542
 msgid ""
 "This module does not comply with the RFC in a strict fashion, implementing "
 "some extensions that are valid JavaScript but not valid JSON.  In particular:"
 msgstr ""
+"Ce module ne se conforme pas strictement à la RFC, implémentant quelques "
+"extensions qui sont valides en JavaScript mais pas en JSON.  En particulier :"
 
 #: ../Doc/library/json.rst:545
 msgid "Infinite and NaN number values are accepted and output;"
-msgstr ""
+msgstr "Les nombres infinis et *NaN* sont acceptés et retranscrits ;"
 
 #: ../Doc/library/json.rst:546
 msgid ""
 "Repeated names within an object are accepted, and only the value of the last "
 "name-value pair is used."
 msgstr ""
+"Les noms répétés au sein d'un objet sont acceptés, seule la valeur du "
+"dernier couple nom/valeur sera utilisée."
 
 #: ../Doc/library/json.rst:549
 msgid ""
@@ -590,10 +780,13 @@ msgid ""
 "not RFC-compliant, this module's deserializer is technically RFC-compliant "
 "under default settings."
 msgstr ""
+"Comme la RFC permet aux analyseurs conformes d'accepter des textes en entrée "
+"non conformes, le désérialiseur de ce module avec ses paramètres par défaut "
+"est techniquement conforme à la RFC."
 
 #: ../Doc/library/json.rst:554
 msgid "Character Encodings"
-msgstr ""
+msgstr "Encodage des caractères"
 
 #: ../Doc/library/json.rst:556
 msgid ""
@@ -601,6 +794,9 @@ msgid ""
 "UTF-32, with UTF-8 being the recommended default for maximum "
 "interoperability."
 msgstr ""
+"La RFC requiert que le JSON soit représenté en utilisant l'encodage UTF-8, "
+"UTF-16 ou UTF-32, avec UTF-8 recommandé par défaut pour une interopérabilité "
+"maximale."
 
 #: ../Doc/library/json.rst:559
 msgid ""
@@ -608,6 +804,10 @@ msgid ""
 "*ensure_ascii=True* by default, thus escaping the output so that the "
 "resulting strings only contain ASCII characters."
 msgstr ""
+"Comme cela est permis par la RFC, bien que non requis, le sérialiseur du "
+"module active *ensure_ascii=True* par défaut, échappant ainsi la sortie de "
+"façon à ce que les chaînes résultants ne contiennent que des caractères "
+"ASCII."
 
 #: ../Doc/library/json.rst:563
 msgid ""
@@ -616,6 +816,9 @@ msgid ""
 "<str>`, and thus does not otherwise directly address the issue of character "
 "encodings."
 msgstr ""
+"Outre le paramètre *ensure_ascii*, les conversions entre objets Python et :"
+"class:`chaînes Unicode <str>` de ce module sont strictement définies, et ne "
+"rencontrent donc pas directement le problème de l'encodage des caractères."
 
 #: ../Doc/library/json.rst:568
 msgid ""
@@ -625,6 +828,11 @@ msgid ""
 "in their input.  This module's deserializer raises a :exc:`ValueError` when "
 "an initial BOM is present."
 msgstr ""
+"La RFC interdit d'ajouter un *byte* marqueur d'ordre (BOM) au début du texte "
+"JSON, et le sérialiseur de ce module n'ajoute pas de tel BOM. La RFC permet, "
+"mais ne requiert pas, que les désérialiseurs JSON ignorent ces BOM.  Le "
+"désérialiseur de ce module lève une :exc:`ValueError` quand un BOM est "
+"présent au début du fichier."
 
 #: ../Doc/library/json.rst:574
 msgid ""
@@ -634,10 +842,16 @@ msgid ""
 "By default, this module accepts and outputs (when present in the original :"
 "class:`str`) code points for such sequences."
 msgstr ""
+"La RFC n'interdit pas explicitement les chaînes JSON contenant des séquences "
+"de *bytes* ne correspondant à aucun caractère Unicode valide (p. ex. les "
+"*surrogates* UTF-16 sans correspondance), mais précise que cela peut causer "
+"des problèmes d'interopérabilité. Par défaut, ce module accepte et "
+"retranscrit (quand présents dans la :class:`str` originale) les *code "
+"points* de telles séquences."
 
 #: ../Doc/library/json.rst:582
 msgid "Infinite and NaN Number Values"
-msgstr ""
+msgstr "Valeurs numériques infinies et NaN"
 
 #: ../Doc/library/json.rst:584
 msgid ""
@@ -645,6 +859,10 @@ msgid ""
 "Despite that, by default, this module accepts and outputs ``Infinity``, ``-"
 "Infinity``, and ``NaN`` as if they were valid JSON number literal values::"
 msgstr ""
+"La RFC ne permet pas la représentation des nombres infinis ou des *NaN*. "
+"Néanmoins, par défaut, ce module accepte et retranscrit ``Infinity``, ``-"
+"Infinity`` et ``NaN`` comme s'ils étaient des valeurs numériques littérales "
+"JSON valides."
 
 #: ../Doc/library/json.rst:599
 msgid ""
@@ -652,10 +870,13 @@ msgid ""
 "behavior.  In the deserializer, the *parse_constant* parameter can be used "
 "to alter this behavior."
 msgstr ""
+"Dans le sérialiseur, le paramètre *allow_nan* peut être utilisé pour altérer "
+"ce comportement.  Dans le désérialiseur, le paramètre *parse_constant* peut "
+"être utilisé pour altérer ce comportement."
 
 #: ../Doc/library/json.rst:605
 msgid "Repeated Names Within an Object"
-msgstr ""
+msgstr "Noms répétés au sein d'un objet"
 
 #: ../Doc/library/json.rst:607
 msgid ""
@@ -664,14 +885,20 @@ msgid ""
 "default, this module does not raise an exception; instead, it ignores all "
 "but the last name-value pair for a given name::"
 msgstr ""
+"La RFC spécifie que les noms au sein d'un objet JSON doivent être uniques, "
+"mais ne décrit pas comment les noms répétés doivent être gérés.  Par défaut, "
+"ce module ne lève pas d'exception ; à la place, il ignore tous les couples "
+"nom/valeur sauf le dernier pour un nom donné : ::"
 
 #: ../Doc/library/json.rst:616
 msgid "The *object_pairs_hook* parameter can be used to alter this behavior."
 msgstr ""
+"Le paramètre *object_pairs_hook* peut être utilisé pour altérer ce "
+"comportement."
 
 #: ../Doc/library/json.rst:620
 msgid "Top-level Non-Object, Non-Array Values"
-msgstr ""
+msgstr "Valeurs de plus haut niveau autres qu'objets ou tableaux"
 
 #: ../Doc/library/json.rst:622
 msgid ""
@@ -682,42 +909,54 @@ msgid ""
 "this module does not and has never implemented that restriction in either "
 "its serializer or its deserializer."
 msgstr ""
+"L'ancienne version de JSON spécifiée par l'obsolète :rfc:`4627` demandait à "
+"ce que la valeur de plus haut niveau du texte JSON soit un objet ou un "
+"tableau JSON (:class:`dict` ou :class:`list` Python), et ne soit pas *null*, "
+"un nombre, ou une chaîne de caractères.  La :rfc:`7159` a supprimé cette "
+"restriction, jamais implémentée par ce module, que ce soit dans le "
+"sérialiseur ou le désérialiseur."
 
 #: ../Doc/library/json.rst:629
 msgid ""
 "Regardless, for maximum interoperability, you may wish to voluntarily adhere "
 "to the restriction yourself."
 msgstr ""
+"Cependant, pour une interopérabilité maximale, vous pourriez volontairement "
+"souhaiter adhérer à cette restriction par vous-même."
 
 #: ../Doc/library/json.rst:634
 msgid "Implementation Limitations"
-msgstr ""
+msgstr "Limitations de l'implémentation"
 
 #: ../Doc/library/json.rst:636
 msgid "Some JSON deserializer implementations may set limits on:"
 msgstr ""
+"Certaines implémentations de désérialiseurs JSON peuvent avoir des limites "
+"sur :"
 
 #: ../Doc/library/json.rst:638
 msgid "the size of accepted JSON texts"
-msgstr ""
+msgstr "la taille des textes JSON acceptés ;"
 
 #: ../Doc/library/json.rst:639
 msgid "the maximum level of nesting of JSON objects and arrays"
-msgstr ""
+msgstr "le niveau maximum d'objets et tableaux JSON imbriqués ;"
 
 #: ../Doc/library/json.rst:640
 msgid "the range and precision of JSON numbers"
-msgstr ""
+msgstr "l'intervalle et la précision des nombres JSON ;"
 
 #: ../Doc/library/json.rst:641
 msgid "the content and maximum length of JSON strings"
-msgstr ""
+msgstr "le contenu et la longueur maximale des chaînes JSON."
 
 #: ../Doc/library/json.rst:643
 msgid ""
 "This module does not impose any such limits beyond those of the relevant "
 "Python datatypes themselves or the Python interpreter itself."
 msgstr ""
+"Ce module n'impose pas de telles limites si ce n'est celles inhérentes aux "
+"types de données Python ou à l'interpréteur."
 
 #: ../Doc/library/json.rst:646
 msgid ""
@@ -729,58 +968,76 @@ msgid ""
 "magnitude, or when serializing instances of \"exotic\" numerical types such "
 "as :class:`decimal.Decimal`."
 msgstr ""
+"Lors d'une sérialisation JSON, faites attention à ces limitations dans les "
+"applications qui utiliseraient votre JSON.  En particulier, il est commun "
+"pour les nombres JSON d'être désérialisés vers des nombres IEEE 754 à "
+"précision double, et donc sujets à l'intervalle et aux limitations sur la "
+"précision de cette représentation.  Cela est d'autant plus important lors de "
+"la sérialisation de valeurs :class:`int` Python de forte magnitude, ou "
+"d'instances de types numériques « exotiques » comme :class:`decimal.Decimal`."
 
 #: ../Doc/library/json.rst:659
 msgid "Command Line Interface"
-msgstr ""
+msgstr "Interface en ligne de commande"
 
 #: ../Doc/library/json.rst:664
 msgid "**Source code:** :source:`Lib/json/tool.py`"
-msgstr ""
+msgstr "**Code source :** :source:`Lib/json/tool.py`"
 
 #: ../Doc/library/json.rst:668
 msgid ""
 "The :mod:`json.tool` module provides a simple command line interface to "
 "validate and pretty-print JSON objects."
 msgstr ""
+"Le module :mod:`json.tool` fournit une simple interface en ligne de commande "
+"pour valider et réécrire élégamment des objets JSON."
 
 #: ../Doc/library/json.rst:671
 msgid ""
 "If the optional ``infile`` and ``outfile`` arguments are not specified, :"
 "attr:`sys.stdin` and :attr:`sys.stdout` will be used respectively::"
 msgstr ""
+"Si les arguments optionnels ``infile`` et ``outfile`` ne sont pas "
+"spécifiés, :attr:`sys.stdin` et :attr:`sys.stdout` seront utilisés "
+"respectivement : ::"
 
 #: ../Doc/library/json.rst:681
 msgid ""
 "The output is now in the same order as the input. Use the :option:`--sort-"
 "keys` option to sort the output of dictionaries alphabetically by key."
 msgstr ""
+"La sortie conserve maintenant l'ordre des données de l'entrée. Utilisez "
+"l'option :option:`--sort-keys` pour sortir des dictionnaires triés "
+"alphabétiquement par clés."
 
 #: ../Doc/library/json.rst:687
 msgid "Command line options"
-msgstr ""
+msgstr "Options de la ligne de commande"
 
 #: ../Doc/library/json.rst:691
 msgid "The JSON file to be validated or pretty-printed::"
-msgstr ""
+msgstr "Le fichier JSON à valider ou réécrire élégamment : ::"
 
 #: ../Doc/library/json.rst:705
 msgid "If *infile* is not specified, read from :attr:`sys.stdin`."
 msgstr ""
+"Si *infile* n'est pas spécifié, lit le document depuis :attr:`sys.stdin`."
 
 #: ../Doc/library/json.rst:709
 msgid ""
 "Write the output of the *infile* to the given *outfile*. Otherwise, write it "
 "to :attr:`sys.stdout`."
 msgstr ""
+"Écrit la sortie générée par *infile* vers le fichier *outfile* donné. "
+"Autrement, écrit sur :attr:`sys.stdout`."
 
 #: ../Doc/library/json.rst:714
 msgid "Sort the output of dictionaries alphabetically by key."
-msgstr ""
+msgstr "Trie alphabétiquement les dictionnaires par clés."
 
 #: ../Doc/library/json.rst:720
 msgid "Show the help message."
-msgstr ""
+msgstr "Affiche le message d'aide."
 
 #: ../Doc/library/json.rst:724
 msgid "Footnotes"
@@ -793,3 +1050,8 @@ msgid ""
 "and U+2029 (PARAGRAPH SEPARATOR) characters in strings, whereas JavaScript "
 "(as of ECMAScript Edition 5.1) does not."
 msgstr ""
+"Comme noté dans `l'errata de la RFC 7159 <https://www.rfc-editor.org/"
+"errata_search.php?rfc=7159>`_, JSON autorise les caractères littéraux U+2028 "
+"(*LINE SEPARATOR*) et U+2029 (*PARAGRAPH SEPARATOR*) dans les chaînes de "
+"caractères, alors que Javascript (selon le standard ECMAScript édition 5.1) "
+"ne le permet pas."

--- a/library/re.po
+++ b/library/re.po
@@ -1658,7 +1658,7 @@ msgstr ""
 
 #: ../Doc/library/re.rst:823
 msgid "The unformatted error message."
-msgstr "Le message d'erreur non formatté."
+msgstr "Le message d'erreur non formaté."
 
 #: ../Doc/library/re.rst:827
 msgid "The regular expression pattern."


### PR DESCRIPTION
Bonsoir,

J'ai fini de compléter les traductions du fichier `library/json.po`.
Je profite de la *PR* pour apporter une correction sur le terme « formaté » dans `library/re.po`.