### PR TITLE
Fix the IRC link in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,7 +137,7 @@ Translation Resources
 ---------------------
 
 - `Le Grand Dictionnaire Terminologique <http://gdt.oqlf.gouv.qc.ca/>`_
-- IRC channel `#python-fr <irc.lc/freenode/python-fr>`_ on freenode.
+- IRC channel `#python-fr <http://irc.lc/freenode/python-fr>`_ on freenode.
 - The `liste traductions <http://lists.afpy.org/mailman/listinfo/traductions>`_.
 - The `doc-sig mailing list
   <https://mail.python.org/mailman/listinfo/doc-sig>`_.


### PR DESCRIPTION
The link was broken because the scheme was missing.