### PR TITLE
Fix translations for `library/modulefinder.po`

### DIFF
--- a/library/modulefinder.po
+++ b/library/modulefinder.po
@@ -101,12 +101,12 @@ msgstr "Exemples d'utilisation de la classe :class:`ModuleFinder`"
 
 #: ../Doc/library/modulefinder.rst:63
 msgid "The script that is going to get analyzed later on (bacon.py)::"
-msgstr "Le script qui sera analysé (bacon.py) ::"
+msgstr "Le script qui sera analysé (bacon.py) : ::"
 
 #: ../Doc/library/modulefinder.rst:78
 msgid "The script that will output the report of bacon.py::"
-msgstr "Le script qui va afficher le rapport de bacon.py ::"
+msgstr "Le script qui va afficher le rapport de bacon.py : ::"
 
 #: ../Doc/library/modulefinder.rst:94
 msgid "Sample output (may vary depending on the architecture)::"
-msgstr "Exemple de sortie (peut varier en fonction de l'architecture) ::"
+msgstr "Exemple de sortie (peut varier en fonction de l'architecture) : ::"

--- a/library/modulefinder.po
+++ b/library/modulefinder.po
@@ -64,8 +64,8 @@ msgid ""
 msgstr ""
 "Cette classe fournit les méthodes :meth:`run_script` et :meth:`report` pour "
 "déterminer l'ensemble des modules importés par un script. *path* peut être "
-"une liste de dossiers dans lesquels chercher les modules ; si non spécifié, "
-"``sys.path`` est utilisé. *debug* définit le niveau de débogage ; des "
+"une liste de dossiers dans lesquels chercher les modules ; si non spécifié, "
+"``sys.path`` est utilisé. *debug* définit le niveau de débogage ; des "
 "valeurs plus élevées produisent plus de détails sur ce que fait la classe. "
 "*excludes* est une liste de noms de modules à exclure de l'analyse. "
 "*replace_paths* est une liste de tuples ``(oldpath, newpath)`` qui seront "
@@ -101,12 +101,12 @@ msgstr "Exemples d'utilisation de la classe :class:`ModuleFinder`"
 
 #: ../Doc/library/modulefinder.rst:63
 msgid "The script that is going to get analyzed later on (bacon.py)::"
-msgstr "Le script qui sera analysé (bacon.py) : ::"
+msgstr "Le script qui sera analysé (bacon.py) : ::"
 
 #: ../Doc/library/modulefinder.rst:78
 msgid "The script that will output the report of bacon.py::"
-msgstr "Le script qui va afficher le rapport de bacon.py : ::"
+msgstr "Le script qui va afficher le rapport de bacon.py : ::"
 
 #: ../Doc/library/modulefinder.rst:94
 msgid "Sample output (may vary depending on the architecture)::"
-msgstr "Exemple de sortie (peut varier en fonction de l'architecture) : ::"
+msgstr "Exemple de sortie (peut varier en fonction de l'architecture) : ::"


### PR DESCRIPTION
* reStructuredText is playful, tokens have a different meaning if they are placed just after a space or a non-space character
* actually use non-breakable spaces