### PR TITLE
Fin de la traduction de tempfile.po

### DIFF
--- a/library/tempfile.po
+++ b/library/tempfile.po
@@ -6,7 +6,7 @@ msgstr ""
 "Project-Id-Version: Python 3.6\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-12-21 09:48+0100\n"
-"PO-Revision-Date: 2019-01-11 17:38+0100\n"
+"PO-Revision-Date: 2019-01-13 22:58+0100\n"
 "Language-Team: FRENCH <traductions@lists.afpy.org>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -206,7 +206,7 @@ msgstr ""
 
 #: ../Doc/library/tempfile.rst:104
 msgid "the truncate method now accepts a ``size`` argument."
-msgstr "La méthode de troncature accepte maintenant un argument ``size``."
+msgstr "la méthode de troncature accepte maintenant un argument ``size``."
 
 #: ../Doc/library/tempfile.rst:110
 msgid ""
@@ -254,12 +254,23 @@ msgid ""
 "executable by no one.  The file descriptor is not inherited by child "
 "processes."
 msgstr ""
+"Crées un fichier temporaire de la manière la plus sécurisée qu'il soit. Il "
+"n'y a pas de situation de compétition (``race condition``) au moment de la "
+"création de fichier, en supposant que la plateforme implémente correctement "
+"l'option :const:`os.O_EXCL` pour :func:`os.open`. Le fichier est seulement "
+"accessible en lecture et écriture par l'ID de l'utilisateur créateur. Si la "
+"plateforme utilise des bits de permissions pour indiquer si le fichier est "
+"exécutable, alors le fichier n'est exécutable par personne. Le descripteur "
+"de fichier n'est pas hérité par les processus fils."
 
 #: ../Doc/library/tempfile.rst:137
 msgid ""
 "Unlike :func:`TemporaryFile`, the user of :func:`mkstemp` is responsible for "
 "deleting the temporary file when done with it."
 msgstr ""
+"À la différence de :func:`TemporaryFile`, l'utilisateur de :func:"
+"`mkstemp` est responsable de la suppression du fichier temporaire quand il "
+"en a fini avec lui."
 
 #: ../Doc/library/tempfile.rst:140
 msgid ""
@@ -268,6 +279,10 @@ msgid ""
 "between the file name and the suffix; if you need one, put it at the "
 "beginning of *suffix*."
 msgstr ""
+"Si *suffix* ne vaut pas ``None``, le nom de fichier se terminera avec ce "
+"suffixe, sinon il n'y aura pas de suffix. :func:`mkstemp` ne mets pas de "
+"point entre le nom du fichier et le suffixe. Si vous en avez besoin, mettez "
+"le point au début de *suffix*."
 
 #: ../Doc/library/tempfile.rst:145
 msgid ""
@@ -275,6 +290,9 @@ msgid ""
 "otherwise, a default prefix is used.  The default is the return value of :"
 "func:`gettempprefix` or :func:`gettempprefixb`, as appropriate."
 msgstr ""
+"Si *prefix* ne vaut pas ``None``, le nom de fichier commencera avec ce "
+"préfixe, sinon un préfixe par défaut est utilisé. La valeur par défaut est "
+"la valeur retournée par :func:`gettempprefix` ou :func:`gettempprefixb`."
 
 #: ../Doc/library/tempfile.rst:149
 msgid ""
@@ -286,6 +304,14 @@ msgid ""
 "any nice properties, such as not requiring quoting when passed to external "
 "commands via ``os.popen()``."
 msgstr ""
+"Si *dir* ne vaut pas ``Ǹone``, le fichier sera crée dans ce répertoire, "
+"autrement, un répertoire par défaut sera utilisé. Le répertoire par défaut "
+"est choisi depuis une liste dépendante de la plateforme, mais l'utilisateur "
+"de l'application peut contrôler l'emplacement du répertoire en spécifiant "
+"les variables d'environnement *TMPDIR*, *TEMP* ou *TMP*. Il n'y a pas de "
+"garantie que le nom de fichier généré aura de bonnes propriétés telles que "
+"ne pas avoir besoin de le mettre entre guillemets lorsque celui-ci est passé "
+"à des commandes externes via ``os.popen()``."
 
 #: ../Doc/library/tempfile.rst:157
 msgid ""
@@ -294,12 +320,19 @@ msgid ""
 "str. If you want to force a bytes return value with otherwise default "
 "behavior, pass ``suffix=b''``."
 msgstr ""
+"Si aucun des paramètres *suffix*, *prefix* et *dir* ne valent `Ǹone``, ils "
+"doivent être du même type. S'ils sont de types **bytes**, la valeur renvoyé "
+"sera en **bytes** au lieu de **str**. Si vous voulez forcer la valeur "
+"renvoyé en **bytes**, passez ``suffix=b\"``."
 
 #: ../Doc/library/tempfile.rst:163
 msgid ""
 "If *text* is specified, it indicates whether to open the file in binary mode "
 "(the default) or text mode.  On some platforms, this makes no difference."
 msgstr ""
+"Si *test* est spécifié, cela indique si le fichier doit être ouvert en mode "
+"binaire (par défaut) ou en mode texte. Sur certaines plateformes, cela ne "
+"fais aucune différence."
 
 #: ../Doc/library/tempfile.rst:167
 msgid ""
@@ -315,6 +348,10 @@ msgid ""
 "and *prefix* now accept and default to ``None`` to cause an appropriate "
 "default value to be used."
 msgstr ""
+"*suffix*, *prefix*, et *dir* peuvent maintenant être spécifiés en *bytes* "
+"pour obtenir un résultat en *bytes*. Avant cela, le type *str* était le seul "
+"autorisé. *suffix* et *prefix* acceptent maintenant la valeur par défaut "
+"``None`` pour que la valeur par défaut appropriée soit utilisé."
 
 #: ../Doc/library/tempfile.rst:180
 msgid ""
@@ -322,22 +359,30 @@ msgid ""
 "no race conditions in the directory's creation.  The directory is readable, "
 "writable, and searchable only by the creating user ID."
 msgstr ""
+"Crées un répertoire temporaire de la manière la plus sécurisée qu'il soit. "
+"Il n'y a pas de situation de compétition (``race condition``) au moment de "
+"la création du répertoire. Le répertoire est accessible en lecture, écriture "
+"uniquement pour l'ID de l'utilisateur créateur."
 
 #: ../Doc/library/tempfile.rst:184
 msgid ""
 "The user of :func:`mkdtemp` is responsible for deleting the temporary "
 "directory and its contents when done with it."
 msgstr ""
+"L'utilisateur de :func:`mkdtemp` est responsable de la suppression du "
+"répertoire temporaire et de son contenu quand il en a fini avec lui."
 
 #: ../Doc/library/tempfile.rst:187
 msgid ""
 "The *prefix*, *suffix*, and *dir* arguments are the same as for :func:"
 "`mkstemp`."
 msgstr ""
+"Les arguments *prefix*, *suffix*, et *dir* sont les mêmes que pour :func:"
+"`mkstemp`."
 
 #: ../Doc/library/tempfile.rst:190
 msgid ":func:`mkdtemp` returns the absolute pathname of the new directory."
-msgstr ""
+msgstr ":func:`mkdtemp` retourne le chemin absolu du nouveau répertoire."
 
 #: ../Doc/library/tempfile.rst:201
 msgid ""
@@ -405,17 +450,20 @@ msgstr ""
 
 #: ../Doc/library/tempfile.rst:229
 msgid "Same as :func:`gettempdir` but the return value is in bytes."
-msgstr ""
+msgstr "Idem que :func:`gettempdir` mais la valeur retournée est en *bytes*."
 
 #: ../Doc/library/tempfile.rst:235
 msgid ""
 "Return the filename prefix used to create temporary files.  This does not "
 "contain the directory component."
 msgstr ""
+"Retourne le préfixe utilisé du nom de fichier pour créer les fichiers "
+"temporaires. Cela ne contient pas le nom du répertoire."
 
 #: ../Doc/library/tempfile.rst:240
 msgid "Same as :func:`gettempprefix` but the return value is in bytes."
 msgstr ""
+"Idem que :func:`gettempprefix` mais la valeur retournée est en *bytes*."
 
 #: ../Doc/library/tempfile.rst:244
 msgid ""
@@ -425,12 +473,21 @@ msgid ""
 "this module take a *dir* argument which can be used to specify the directory "
 "and this is the recommended approach."
 msgstr ""
+"Le module utilise une variable globale pour stocker le nom du répertoire "
+"utilisé pour les fichiers temporaires renvoyés par :func:`gettempdir`. On "
+"peut directement utiliser la variable globale pour surcharger le processus "
+"de sélection, mais ceci est déconseillé. Toutes les fonctions de ce module "
+"prennent un argument *dir qui peut être utilisé pour spécifier le "
+"répertoire. Il s'agit de la méthode recommandé."
 
 #: ../Doc/library/tempfile.rst:252
 msgid ""
 "When set to a value other than ``None``, this variable defines the default "
 "value for the *dir* argument to the functions defined in this module."
 msgstr ""
+"Quand une valeur autre que ``None`` est spécifiée, cette variable définit la "
+"valeur par défaut pour l'argument *dir* des fonctions définies dans ce "
+"module."
 
 #: ../Doc/library/tempfile.rst:256
 msgid ""
@@ -438,6 +495,9 @@ msgid ""
 "functions except :func:`gettempprefix` it is initialized following the "
 "algorithm described in :func:`gettempdir`."
 msgstr ""
+"Si ``tempdir`` vaut ``None`` (par défaut) pour n'importe quelle des "
+"fonctions ci-dessus, sauf :func:`gettempprefix`, la variable est initialisée "
+"suivant l'algorithme décrit dans :func:`gettempdir`."
 
 #: ../Doc/library/tempfile.rst:263
 msgid "Examples"
@@ -446,10 +506,12 @@ msgstr "Exemples"
 #: ../Doc/library/tempfile.rst:265
 msgid "Here are some examples of typical usage of the :mod:`tempfile` module::"
 msgstr ""
+"Voici quelques exemples classiques d'utilisation du module :mod:`tempfile` "
+"module::"
 
 #: ../Doc/library/tempfile.rst:296
 msgid "Deprecated functions and variables"
-msgstr ""
+msgstr "Fonctions et variables dépréciées"
 
 #: ../Doc/library/tempfile.rst:298
 msgid ""
@@ -461,10 +523,18 @@ msgid ""
 "to combine the two steps and create the file immediately. This approach is "
 "used by :func:`mkstemp` and the other functions described above."
 msgstr ""
+"Historiquement, la méthode pour créer des fichiers temporaires consistait à "
+"générer un nom de fichier avec la fonction :func:`mktemp` et créer un "
+"fichier en utilisant ce nom. Malheureusement, cette méthode n'est pas fiable "
+"car un autre processus peut créer un fichier avec ce nom entre l'appel à la "
+"fonction :func:`mktemp` et la tentative de création de fichier par le "
+"premier processus en cours. La solution est de combiner les deux étapes et "
+"de créer le fichier immédiatement. Cette approche est utilisée par :func:"
+"`mkstemp` et les autres fonctions décrites plus haut."
 
 #: ../Doc/library/tempfile.rst:309
 msgid "Use :func:`mkstemp` instead."
-msgstr ""
+msgstr "Utilisez :func:`mkstemp` à la place."
 
 #: ../Doc/library/tempfile.rst:312
 msgid ""
@@ -473,6 +543,10 @@ msgid ""
 "those of :func:`mkstemp`, except that bytes file names, ``suffix=None`` and "
 "``prefix=None`` are not supported."
 msgstr ""
+"Retourne le chemin absolu d'un fichier qui n'existe pas lorsque l'appel est "
+"fait. Les arguments *prefix*, *suffix*, et *dir* sont similaires à ceux de :"
+"func:`mkstemp` mais les noms de fichiers en _bytes_, ``sufix=None`` et "
+"``prefix=None`` ne sont pas supportés."
 
 #: ../Doc/library/tempfile.rst:319
 msgid ""
@@ -482,3 +556,8 @@ msgid ""
 "easily with :func:`NamedTemporaryFile`, passing it the ``delete=False`` "
 "parameter::"
 msgstr ""
+"Utiliser cette fonction peut introduire un trou de sécurité dans votre "
+"programme. Le temps que vous fassiez quelque chose avec le nom de fichier "
+"retourné, quelqu'un d'autre peut vous avoir botté les fesses avant. "
+"L'utilisation de :func:`mktemp` peut être remplacé facilement avec :func:"
+"`NamedTemporaryFile` en y passant le paramètre ``delete=False``::"


### PR DESCRIPTION
Salut @JulienPalard et @Seluj78 !

J'ai eu un petit problème de traduction sur cette phrase : 

`:func:`mkstemp` returns a tuple containing an OS-level handle to an open file (as would be returned by :func:`os.open`) and the absolute pathname of that file, in that order.`

C'est le terme 'OS-level handle' que je ne sais pas du tout comment traduire. Vous avez des suggestions ? 

Sinon, à part ça, j'ai terminé le module tempfile ! 