### PR TITLE
Correction de typo dans functions (description de repr)

### DIFF
--- a/library/functions.po
+++ b/library/functions.po
@@ -2401,7 +2401,7 @@ msgstr ""
 "représentation sera une chaîne entourée de chevrons contenant le nom du type "
 "et quelques informations supplémentaires souvent le nom et l'adresse de "
 "l'objet. Une classe peut contrôler ce que cette fonction donne pour ses "
-"instances en définissant une méthode :meth:`_repr__`."
+"instances en définissant une méthode :meth:`__repr__`."
 
 #: ../Doc/library/functions.rst:1331
 msgid ""


### PR DESCRIPTION
#569 correction d'une typo, répare un lien automatique.