### PR TITLE
corrige une balise cassée

### DIFF
--- a/faq/general.po
+++ b/faq/general.po
@@ -409,7 +409,7 @@ msgid ""
 "source for the documentation is part of the Python source distribution."
 msgstr ""
 "La documentation est écrite au format *reStructuredText* et traitée par "
-"l'outil de documentation Sphinx <http://sphinx-doc.org/>`__. La source du "
+"l'outil de documentation `Sphinx <http://sphinx-doc.org/>`__. La source du "
 "*reStructuredText* pour la documentation constitue une partie des sources de "
 "Python."
 


### PR DESCRIPTION
je mets pas tout le texte d'origine dans la balise (*sphinx documentation tool*) et c'est voulu. 