### PR TITLE
répare le README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -344,8 +344,8 @@ prompt                     invite
 raise                      lever
 regular expression         expression rationnelle, expression régulière
 return                     renvoie, donne (on évite
-setter                     mutateur
                            "retourne" qui pourrait porter à confusion).
+setter                     mutateur
 simple quote               guillemet simple, apostrophe (apostrophe
                            is to glue, guillemet is to surround)
 socket                     *socket*


### PR DESCRIPTION
la ligne de 'setter' que j'ai ajouté dans le README coupe celle de 'return', et casse le README. 