### PR TITLE
wrap reference/import.po (pour réparer la CI)

### DIFF
--- a/howto/unicode.po
+++ b/howto/unicode.po
@@ -608,7 +608,7 @@ msgid ""
 "algorithm described by the Unicode Standard.  This algorithm has special "
 "handling for characters such as the German letter 'ß' (code point U+00DF), "
 "which becomes the pair of lowercase letters 'ss'."
-msgstr "pouette « ss » pouette"
+msgstr ""
 
 #: ../Doc/howto/unicode.rst:424
 msgid ""

--- a/reference/import.po
+++ b/reference/import.po
@@ -1871,8 +1871,8 @@ msgid ""
 "this is that::"
 msgstr ""
 "Les importations absolues peuvent utiliser soit la syntaxe ``import <>``, "
-"soit ``from <> import <>``, mais les importations relatives doivent seulement "
-"utiliser la deuxième forme, la raison étant ::"
+"soit ``from <> import <>``, mais les importations relatives doivent "
+"seulement utiliser la deuxième forme, la raison étant ::"
 
 #: ../Doc/reference/import.rst:961
 msgid ""


### PR DESCRIPTION
Christophe a cassé le master en oubliant de wrapper `reference/import.po` lors de #797, qui a été mergée, et Julien a introduit une string contenant `pouette « ss » pouette` lors de fa3683a1de8106185232e2e23eec5139da9575d2, du coup la CI voit rouge tout le temps :)