### PR TITLE
README: mauvais nombre de tirets pour em-dash + mauvais caractère en-dash

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -230,7 +230,7 @@ rapidement des problèmes dans d'autres langues.
 Nous l'avons donc désactivée.
 
 Les *smartquotes* sont également responsables de la transformation de
-``--`` en *en-dash* (``-``), de ``-----`` en *em-dash* (``—``), et de
+``--`` en *en-dash* (``–``), de ``---`` en *em-dash* (``—``), et de
 ``...`` en ``…``.
 
 Comme nous n'avons pas de *smartquotes*, nous devrons également « traduire »


### PR DESCRIPTION
 Lors de la traduction j'ai changé accidentellement le nombre de tirets simples nécéssaires à faire un em-dash (j'en ai mis 5 au lieu 3) et incorrectement changé le caractère du en-dash par un mauvais (tiret simple).