### PR TITLE
howto/functional: espaces insécables avant les deux-points

### DIFF
--- a/howto/functional.po
+++ b/howto/functional.po
@@ -69,7 +69,7 @@ msgid ""
 "Programming languages support decomposing problems in several different ways:"
 msgstr ""
 "Les langages de programmation permettent de traiter des problèmes selon "
-"différentes approches :"
+"différentes approches :"
 
 #: ../Doc/howto/functional.rst:24
 msgid ""
@@ -238,7 +238,7 @@ msgid ""
 msgstr ""
 "Programmer sous la contrainte du paradigme fonctionnel peut sembler étrange. "
 "Pourquoi vouloir éviter les objets et les effets de bord ? Il existe des "
-"avantages théoriques et pratiques au style fonctionnel :"
+"avantages théoriques et pratiques au style fonctionnel :"
 
 #: ../Doc/howto/functional.rst:93
 msgid "Formal provability."
@@ -473,7 +473,7 @@ msgstr ""
 
 #: ../Doc/howto/functional.rst:199
 msgid "You can experiment with the iteration interface manually:"
-msgstr "Vous pouvez expérimenter avec l'interface d'itération manuellement :"
+msgstr "Vous pouvez expérimenter avec l'interface d'itération manuellement :"
 
 #: ../Doc/howto/functional.rst:217
 msgid ""
@@ -493,7 +493,7 @@ msgid ""
 "or :func:`tuple` constructor functions:"
 msgstr ""
 "Les itérateurs peuvent être transformés en listes ou en tuples en appelant "
-"les constructeurs respectifs :func:`list` et :func:`tuple` :"
+"les constructeurs respectifs :func:`list` et :func:`tuple` :"
 
 #: ../Doc/howto/functional.rst:238
 msgid ""
@@ -502,7 +502,7 @@ msgid ""
 msgstr ""
 "Le dépaquetage de séquences fonctionne également sur les itérateurs : si "
 "vous savez qu'un itérateur renvoie N éléments, vous pouvez les dépaqueter "
-"dans un n-uplet :"
+"dans un n-uplet :"
 
 #: ../Doc/howto/functional.rst:247
 msgid ""
@@ -594,7 +594,7 @@ msgid ""
 "stream of ``(key, value)`` tuples:"
 msgstr ""
 "Le constructeur :func:`dict` accepte de prendre un itérateur en argument qui "
-"renvoie un flux fini de pairs ``(clé, valeur)`` :"
+"renvoie un flux fini de pairs ``(clé, valeur)`` :"
 
 #: ../Doc/howto/functional.rst:308
 msgid ""
@@ -746,7 +746,7 @@ msgstr ""
 "Ainsi lorsque plusieurs clauses ``for ... in`` sont présentes mais sans "
 "condition ``if``, la longueur totale de la nouvelle séquence est égale au "
 "produit des longueurs des séquences itérées. Si vous travaillez sur deux "
-"listes de longueur 3, la sortie contiendra 9 éléments :"
+"listes de longueur 3, la sortie contiendra 9 éléments :"
 
 #: ../Doc/howto/functional.rst:420
 msgid ""
@@ -800,7 +800,7 @@ msgstr ""
 
 #: ../Doc/howto/functional.rst:446
 msgid "Here's the simplest example of a generator function:"
-msgstr "Voici un exemple simple de fonction génératrice :"
+msgstr "Voici un exemple simple de fonction génératrice :"
 
 #: ../Doc/howto/functional.rst:452
 msgid ""
@@ -834,7 +834,7 @@ msgstr ""
 
 #: ../Doc/howto/functional.rst:465
 msgid "Here's a sample usage of the ``generate_ints()`` generator:"
-msgstr "Voici un exemple d'utilisation du générateur ``generate_ints()`` :"
+msgstr "Voici un exemple d'utilisation du générateur ``generate_ints()`` :"
 
 #: ../Doc/howto/functional.rst:482
 msgid ""
@@ -983,7 +983,7 @@ msgstr ""
 
 #: ../Doc/howto/functional.rst:568
 msgid "And here's an example of changing the counter:"
-msgstr "Et voici comment il est possible de modifier le compteur :"
+msgstr "Et voici comment il est possible de modifier le compteur :"
 
 #: ../Doc/howto/functional.rst:585
 msgid ""
@@ -1003,7 +1003,7 @@ msgid ""
 "generators:"
 msgstr ""
 "En plus de :meth:`~generator.send`, il existe deux autres méthodes "
-"s'appliquant aux générateurs :"
+"s'appliquant aux générateurs :"
 
 #: ../Doc/howto/functional.rst:593
 msgid ""
@@ -1084,7 +1084,7 @@ msgid ""
 "the features of generator expressions:"
 msgstr ""
 ":func:`map` et :func:`filter` sont deux fonctions natives de Python qui "
-"clonent les propriétés des expressions génératrices :"
+"clonent les propriétés des expressions génératrices :"
 
 #: ../Doc/howto/functional.rst:634
 msgid ""
@@ -1121,7 +1121,7 @@ msgstr ""
 
 #: ../Doc/howto/functional.rst:651
 msgid "This can also be written as a list comprehension:"
-msgstr "Cela peut se réécrire sous la forme d'une compréhension de liste :"
+msgstr "Cela peut se réécrire sous la forme d'une compréhension de liste :"
 
 #: ../Doc/howto/functional.rst:657
 msgid ""
@@ -1172,7 +1172,7 @@ msgstr ""
 "permettent d'observer les valeurs de vérité des éléments d'un itérable. :"
 "func:`any` renvoie ``True`` si au moins un élément de l'itérable s'évalue "
 "comme vrai et :func:`all` renvoie ``True`` si tous les éléments s'évaluent "
-"comme vrai :"
+"comme vrai :"
 
 #: ../Doc/howto/functional.rst:712
 msgid ""
@@ -1233,7 +1233,7 @@ msgstr ""
 
 #: ../Doc/howto/functional.rst:742
 msgid "The module's functions fall into a few broad classes:"
-msgstr "Les fonctions du module se divisent en quelques grandes catégories :"
+msgstr "Les fonctions du module se divisent en quelques grandes catégories :"
 
 #: ../Doc/howto/functional.rst:744
 msgid "Functions that create a new iterator based on an existing iterator."
@@ -1614,7 +1614,7 @@ msgstr ""
 "Si vous combinez :func:`operator.add` avec :func:`functools.reduce`, vous "
 "allez additionner tous les éléments de l'itérable. Ce cas est suffisamment "
 "courant pour qu'il existe une fonction native :func:`sum` qui lui est "
-"équivalent :"
+"équivalent :"
 
 #: ../Doc/howto/functional.rst:1055
 msgid ""
@@ -1656,7 +1656,7 @@ msgstr ""
 
 #: ../Doc/howto/functional.rst:1087
 msgid "Some of the functions in this module are:"
-msgstr "Voici quelques fonctions de ce module :"
+msgstr "Voici quelques fonctions de ce module :"
 
 #: ../Doc/howto/functional.rst:1089
 msgid ""
@@ -1793,7 +1793,7 @@ msgid ""
 "of ``lambda``:"
 msgstr ""
 "Frederik Lundh a suggéré quelques règles pour le réusinage de code "
-"impliquant les expressions ``lambda`` :"
+"impliquant les expressions ``lambda`` :"
 
 #: ../Doc/howto/functional.rst:1166
 msgid "Write a lambda function."


### PR DESCRIPTION
Ça se voyait lorsqu'on lisait la doc dans une petite fenêtre : les deux-points allaient tout seuls à la ligne suivante