### PR TITLE
ajout de "backtrace/stacktrace" -> "pile d'appels, trace de pile" dans le glossaire

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -403,6 +403,7 @@ Terme                      Traduction proposée
 abstract data type         type abstrait
 argument                   argument (à ne pas confondre avec *paramètre*)
 backslash                  antislash, *backslash*
+backtrace                  trace d'appels, trace de pile
 bound                      lier
 bug                        bogue, *bug*
 built-in                   native
@@ -454,6 +455,7 @@ socket                     connecteur ou interface de connexion
 statement                  instruction
 subprocess                 sous-processus
 thread                     fil d'exécution
+traceback                  trace d'appels, trace de pile
 underscore                 tiret bas, *underscore*
 ========================== ===============================================
 


### PR DESCRIPTION
à la suite de #979 