### PR TITLE
Tell where html is output, and how to see them.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,14 @@ ifneq "$(shell cd $(CPYTHON_CLONE) 2>/dev/null && git describe --contains --all 
 endif
 	mkdir -p $(CPYTHON_CLONE)/locales/$(LANGUAGE)/
 	ln -nfs $(shell $(PYTHON) -c 'import os; print(os.path.realpath("."))') $(CPYTHON_CLONE)/locales/$(LANGUAGE)/LC_MESSAGES
-	$(MAKE) -C $(CPYTHON_CLONE)/Doc/ VENVDIR=$(VENV) PYTHON=$(PYTHON) SPHINXOPTS='-qW -j$(JOBS) -D locale_dirs=../locales -D language=$(LANGUAGE) -D gettext_compact=0 -D latex_engine=xelatex -D latex_elements.inputenc= -D latex_elements.fontenc=' $(MODE)
+	$(MAKE) -C $(CPYTHON_CLONE)/Doc/ VENVDIR=$(VENV) PYTHON=$(PYTHON) \
+	  SPHINXOPTS='-qW -j$(JOBS) -D locale_dirs=../locales -D language=$(LANGUAGE) -D gettext_compact=0 -D latex_engine=xelatex -D latex_elements.inputenc= -D latex_elements.fontenc=' \
+	  $(MODE) && echo "Build success, files in $(CPYTHON_CLONE)Doc/build/$(MODE), run 'make serve' or 'python3 -m http.server -d $(CPYTHON_CLONE)Doc/build/$(MODE)' to see them."
+
+
+.PHONY: serve
+serve:
+	$(MAKE) -C $(CPYTHON_CLONE)/Doc/ serve
 
 
 $(SPHINX_CONF):


### PR DESCRIPTION
This shows:
```
Build success, files in ../cpython/Doc/build/html, run 'make serve' or 'python3 -m http.server -d ../cpython/Doc/build/html' to see them.
```

after a `make`. 

Then `make serve` gives:
```
$ make serve
make -C ../cpython//Doc/ serve
make[1]: Entering directory '/home/mdk/clones/python/cpython/Doc'
python3 ../Tools/scripts/serve.py build/html
Serving build/html on port 8000, control-C to stop
127.0.0.1 - - [14/Nov/2019 23:48:53] "GET / HTTP/1.1" 200 10365
```