### PR TITLE
Forgot that command substitution removes trailing newlines.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ install:
   - pospell --version
   - powrap --version
 script:
-  - printf "%s\n" "$TRAVIS_COMMIT_RANGE"
-  - CHANGED_FILES="$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep '\.po$';:)"
-  - 'printf "%s files changed.\n" "$(printf "%s" "$CHANGED_FILES" | wc -l)"'
-  - 'printf -- "- %s\n" $CHANGED_FILES | grep -v "^- $" || :'
+  - 'printf "%s\n" "$TRAVIS_COMMIT_RANGE"'
+  - 'CHANGED_FILES="$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep "\.po$")" ;:'
+  - 'printf "%s files changed.\n" "$(printf "%s" "$CHANGED_FILES" | grep -c "po$")" ;:'
+  - '[ -n "$CHANGED_FILES" ] && printf -- "- %s\n" $CHANGED_FILES ;:'
   - 'powrap --check --quiet *.po */*.po'
   - 'pospell -p dict -l fr_FR *.po */*.po'
   - 'make CPYTHON_CLONE=/tmp/cpython/ COMMIT=4d1abedce9422473af2ac78047e55cde73208208'


### PR DESCRIPTION
So I use `grep -c` instead of `wc -l`, to also count the last line, which does not end to a newline due to bash removing it. grep works as expected to count lines, see:

```
$ printf "" | wc -l
0  # Right!
$ printf "" | grep -c ''
0  # Right!
$ printf "a line" | wc -l
0  # Wrong but it's not wc -l fault, files should end with newlines anyway.
$ printf "a line" | grep -c ''
1  # Right!
```