### PR TITLE
Propose to directly open static files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,11 @@
 # documented in gen/src/3.6/Doc/Makefile as we're only delegating the
 # real work to the Python Doc Makefile.
 
-CPYTHON_CLONE := ../cpython/
+CPYTHON_CLONE := $(realpath ../cpython/)
 SPHINX_CONF := $(CPYTHON_CLONE)/Doc/conf.py
 LANGUAGE := fr
-VENV := $(shell pwd)/venv/
+CWD := $(shell pwd)
+VENV := $(CWD)/venv/
 PYTHON := $(shell which python3)
 MODE := html
 BRANCH = 3.8
@@ -36,7 +37,7 @@ endif
 	ln -nfs $(shell $(PYTHON) -c 'import os; print(os.path.realpath("."))') $(CPYTHON_CLONE)/locales/$(LANGUAGE)/LC_MESSAGES
 	$(MAKE) -C $(CPYTHON_CLONE)/Doc/ VENVDIR=$(VENV) PYTHON=$(PYTHON) \
 	  SPHINXOPTS='-qW -j$(JOBS) -D locale_dirs=../locales -D language=$(LANGUAGE) -D gettext_compact=0 -D latex_engine=xelatex -D latex_elements.inputenc= -D latex_elements.fontenc=' \
-	  $(MODE) && echo "Build success, files in $(CPYTHON_CLONE)Doc/build/$(MODE), run 'make serve' or 'python3 -m http.server -d $(CPYTHON_CLONE)Doc/build/$(MODE)' to see them."
+	  $(MODE) && echo "Build success, open file://$(CPYTHON_CLONE)/Doc/build/html/index.html or run 'make serve' to see them."
 
 
 .PHONY: serve

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,7 @@
 CPYTHON_CLONE := $(realpath ../cpython/)
 SPHINX_CONF := $(CPYTHON_CLONE)/Doc/conf.py
 LANGUAGE := fr
-CWD := $(shell pwd)
-VENV := $(CWD)/venv/
+VENV := $(shell pwd)/venv/
 PYTHON := $(shell which python3)
 MODE := html
 BRANCH = 3.8


### PR DESCRIPTION
Ça affiche :
```
Build success, open file:///home/mdk/clones/python/cpython/Doc/build/html/index.html or run 'make serve' to see them.
```

et dans certains émulateurs de terminal, ce lien est cliquable, et donc l'utilisateur peut directement aller lire la doc sans avoir a taper `python3 -m http.server...` ou même `make serve`, juste à cliquer.