### PR TITLE
Fix reference to PEP 238 in library/__future__.po translation

### DIFF
--- a/library/__future__.po
+++ b/library/__future__.po
@@ -204,7 +204,7 @@ msgstr "3.0"
 
 #: ../Doc/library/__future__.rst:75
 msgid ":pep:`238`: *Changing the Division Operator*"
-msgstr ":pep:`328` : *Changement de l'opérateur de division*"
+msgstr ":pep:`238` : *Changement de l'opérateur de division*"
 
 #: ../Doc/library/__future__.rst:78
 msgid "absolute_import"


### PR DESCRIPTION
As explained in https://bugs.python.org/issue39861, a typo in the French translation of `library/__future__.po` makes the wrong reference to PEP 328 instead of PEP 238.

I'm not sure if I followed the correct contributing guidelines since I'm not fluent in French. Let me know if I need to take further action to fix this minor bug.