### PR TITLE
tutorial/errors.po: corrige erreur powrap due commentaire gettext

### DIFF
--- a/tutorial/errors.po
+++ b/tutorial/errors.po
@@ -528,7 +528,7 @@ msgstr ""
 "Certains objets définissent des actions de nettoyage standards qui doivent "
 "être exécutées lorsque l'objet n'est plus nécessaire, indépendamment du fait "
 "que l'opération ayant utilisé l'objet ait réussi ou non. Regardez l'exemple "
-"suivant, qui tente d'ouvrir un fichier et d'afficher son contenu à l'écran ::"
+"suivant, qui tente d'ouvrir un fichier et d'afficher son contenu à l'écran ::"
 
 #: ../Doc/tutorial/errors.rst:413
 msgid ""

--- a/tutorial/errors.po
+++ b/tutorial/errors.po
@@ -149,8 +149,8 @@ msgstr ""
 "générée par l'utilisateur est signalée en levant l'exception :exc:"
 "`KeyboardInterrupt`. ::"
 
-#: ../Doc/tutorial/errors.rst:96
 # début d'énumération
+#: ../Doc/tutorial/errors.rst:96
 msgid "The :keyword:`try` statement works as follows."
 msgstr "L'instruction :keyword:`try` fonctionne comme ceci :"
 
@@ -183,8 +183,8 @@ msgstr ""
 "correspondante est exécutée, puis l'exécution continue après l'instruction :"
 "keyword:`try`."
 
-#: ../Doc/tutorial/errors.rst:109
 # dernier élément de l'énumération
+#: ../Doc/tutorial/errors.rst:109
 msgid ""
 "If an exception occurs which does not match the exception named in the "
 "except clause, it is passed on to outer :keyword:`try` statements; if no "


### PR DESCRIPTION
bien que valide, powrap aime pas l'endroit où j'ai placé les commentaires gettext. Cette PR corrige cela.