### PR TITLE
Améliorations de la section « Ressources de traduction » de CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -467,11 +467,8 @@ Ressources de traduction
 - des glossaires et dictionnaires :
   
   - le `glossaire de la documentation Python <https://docs.python.org/fr/3/glossary.html>`_, car il est déjà traduit,
-  - les `glossaires et dictionnaires de traduc.org <https://traduc.org/Glossaires_et_dictionnaires>`_, en particulier le
-  `grand dictionnaire terminologique <http://gdt.oqlf.gouv.qc.ca/>`_ de l'Office québécois de la langue française ;
-  - Wikipédia. En consultant un article sur la version anglaise,
-  puis en basculant sur la version francaise pour voir
-  comment le sujet de l'article est traduit.
+  - les `glossaires et dictionnaires de traduc.org <https://traduc.org/Glossaires_et_dictionnaires>`_, en particulier le  `grand dictionnaire terminologique <http://gdt.oqlf.gouv.qc.ca/>`_ de l'Office québécois de la langue française ;
+  - Wikipédia. En consultant un article sur la version anglaise, puis en basculant sur la version francaise pour voir comment le sujet de l'article est traduit.
 - le `guide stylistique pour le français de localisation des produits Sun
   <https://web.archive.org/web/20160821182818/http://frenchmozilla.org/FTP/TEMP/guide_stylistique_December05.pdf>`_ donne
   beaucoup de conseils pour éviter une traduction trop mot à mot ;

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -460,9 +460,10 @@ Ressources de traduction
   - `#python-docs-fr <http://irc.lc/freenode/python-docs-fr>`_ — communauté python autour de la documentation française,
   - `#python-fr <http://irc.lc/freenode/python-fr>`_  — communauté python francophone,
   - `#python-doc <http://irc.lc/freenode/python-fr>`_ — communauté python autour de la documentation anglophone ;
-- la `liste de diffusion de traductions de l'AFPy <http://lists.afpy.org/mailman/listinfo/traductions>`_ ;
-- la `liste de diffusion doc-sig
-  <https://mail.python.org/mailman/listinfo/doc-sig>`_ ;
+- les listes de diffusion relatives à la documentation (courriel) :
+
+  - `de l'AFPy <http://lists.afpy.org/mailman/listinfo/traductions>`_,
+  - `de cpython <https://mail.python.org/mailman/listinfo/doc-sig>`_ ;
 - les `glossaires et dictionnaires de traduc.org
   <https://traduc.org/Glossaires_et_dictionnaires>`_, en particulier le
   `grand dictionnaire terminologique <http://gdt.oqlf.gouv.qc.ca/>`_

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -464,18 +464,19 @@ Ressources de traduction
 
   - `de l'AFPy <http://lists.afpy.org/mailman/listinfo/traductions>`_,
   - `de cpython <https://mail.python.org/mailman/listinfo/doc-sig>`_ ;
-- les `glossaires et dictionnaires de traduc.org
+- des glossaires et dictionnaires :
+  
+  - le `glossaire de la documentation Python <https://docs.python.org/fr/3/glossary.html>`_, car il est déjà traduit,
+  - les `glossaires et dictionnaires de traduc.org
   <https://traduc.org/Glossaires_et_dictionnaires>`_, en particulier le
   `grand dictionnaire terminologique <http://gdt.oqlf.gouv.qc.ca/>`_
   de l'Office québécois de la langue française ;
-- le `glossaire Python <https://docs.python.org/fr/3/glossary.html>`_, car
-  il est déjà traduit ;
+  - Wikipédia. En consultant un article sur la version anglaise,
+  puis en basculant sur la version francaise pour voir
+  comment le sujet de l'article est traduit.
 - le `guide stylistique pour le français de localisation des produits Sun
   <https://web.archive.org/web/20160821182818/http://frenchmozilla.org/FTP/TEMP/guide_stylistique_December05.pdf>`_ donne
   beaucoup de conseils pour éviter une traduction trop mot à mot ;
-- Wikipédia. En consultant un article sur la version anglaise,
-  puis en basculant sur la version francaise pour voir
-  comment le sujet de l'article est traduit.
 - `Petites leçons de typographie <https://jacques-andre.fr/faqtypo/lessons.pdf>`_,
   résumé succint de typographie, utile pour apprendre le bon usage des
   majuscules, des espaces, etc.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -467,10 +467,8 @@ Ressources de traduction
 - des glossaires et dictionnaires :
   
   - le `glossaire de la documentation Python <https://docs.python.org/fr/3/glossary.html>`_, car il est déjà traduit,
-  - les `glossaires et dictionnaires de traduc.org
-  <https://traduc.org/Glossaires_et_dictionnaires>`_, en particulier le
-  `grand dictionnaire terminologique <http://gdt.oqlf.gouv.qc.ca/>`_
-  de l'Office québécois de la langue française ;
+  - les `glossaires et dictionnaires de traduc.org <https://traduc.org/Glossaires_et_dictionnaires>`_, en particulier le
+  `grand dictionnaire terminologique <http://gdt.oqlf.gouv.qc.ca/>`_ de l'Office québécois de la langue française ;
   - Wikipédia. En consultant un article sur la version anglaise,
   puis en basculant sur la version francaise pour voir
   comment le sujet de l'article est traduit.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -457,12 +457,9 @@ Ressources de traduction
 
 - les canaux IRC sur freenode :
 
-  - `#python-docs-fr <http://irc.lc/freenode/python-docs-fr>`_
-  communauté python autour de la documentation française,
-  - `#python-fr <http://irc.lc/freenode/python-fr>`_
-  communauté python francophone,
-  - `#python-doc <http://irc.lc/freenode/python-fr>`_
-  communauté python autour de la documentation anglophone ;
+  - `#python-docs-fr <http://irc.lc/freenode/python-docs-fr>`_ communauté python autour de la documentation française,
+  - `#python-fr <http://irc.lc/freenode/python-fr>`_  communauté python francophone,
+  - `#python-doc <http://irc.lc/freenode/python-fr>`_ communauté python autour de la documentation anglophone ;
 - la `liste traductions AFPy <http://lists.afpy.org/mailman/listinfo/traductions>`_ ;
 - la `liste de diffusion doc-sig
   <https://mail.python.org/mailman/listinfo/doc-sig>`_ ;

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -467,7 +467,7 @@ Ressources de traduction
 - des glossaires et dictionnaires :
   
   - le `glossaire de la documentation Python <https://docs.python.org/fr/3/glossary.html>`_, car il est déjà traduit,
-  - les `glossaires et dictionnaires de traduc.org <https://traduc.org/Glossaires_et_dictionnaires>`_, en particulier le  `grand dictionnaire terminologique <http://gdt.oqlf.gouv.qc.ca/>`_ de l'Office québécois de la langue française ;
+  - les `glossaires et dictionnaires de traduc.org <https://traduc.org/Glossaires_et_dictionnaires>`_, en particulier le  `grand dictionnaire terminologique <http://gdt.oqlf.gouv.qc.ca/>`_ de l'Office québécois de la langue française,
   - Wikipédia. En consultant un article sur la version anglaise, puis en basculant sur la version francaise pour voir comment le sujet de l'article est traduit.
 - le `guide stylistique pour le français de localisation des produits Sun
   <https://web.archive.org/web/20160821182818/http://frenchmozilla.org/FTP/TEMP/guide_stylistique_December05.pdf>`_ donne

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -457,10 +457,10 @@ Ressources de traduction
 
 - les canaux IRC sur freenode :
 
-  - `#python-docs-fr <http://irc.lc/freenode/python-docs-fr>`_ communauté python autour de la documentation française,
-  - `#python-fr <http://irc.lc/freenode/python-fr>`_  communauté python francophone,
-  - `#python-doc <http://irc.lc/freenode/python-fr>`_ communauté python autour de la documentation anglophone ;
-- la `liste traductions AFPy <http://lists.afpy.org/mailman/listinfo/traductions>`_ ;
+  - `#python-docs-fr <http://irc.lc/freenode/python-docs-fr>`_ — communauté python autour de la documentation française,
+  - `#python-fr <http://irc.lc/freenode/python-fr>`_  — communauté python francophone,
+  - `#python-doc <http://irc.lc/freenode/python-fr>`_ — communauté python autour de la documentation anglophone ;
+- la `liste de diffusion de traductions de l'AFPy <http://lists.afpy.org/mailman/listinfo/traductions>`_ ;
 - la `liste de diffusion doc-sig
   <https://mail.python.org/mailman/listinfo/doc-sig>`_ ;
 - les `glossaires et dictionnaires de traduc.org
@@ -472,9 +472,9 @@ Ressources de traduction
 - le `guide stylistique pour le français de localisation des produits Sun
   <https://web.archive.org/web/20160821182818/http://frenchmozilla.org/FTP/TEMP/guide_stylistique_December05.pdf>`_ donne
   beaucoup de conseils pour éviter une traduction trop mot à mot ;
-- Wikipédia. En allant sur l'article d'un sujet sur la version anglaise
-  de Wikipédia, puis en basculant sur la version francaise pour voir
-  comment le sujet est traduit.
+- Wikipédia. En consultant un article sur la version anglaise,
+  puis en basculant sur la version francaise pour voir
+  comment le sujet de l'article est traduit.
 - `Petites leçons de typographie <https://jacques-andre.fr/faqtypo/lessons.pdf>`_,
   résumé succint de typographie, utile pour apprendre le bon usage des
   majuscules, des espaces, etc.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -456,12 +456,13 @@ Ressources de traduction
 -------------------------
 
 - les canaux IRC sur freenode :
+
   - `#python-docs-fr <http://irc.lc/freenode/python-docs-fr>`_
-  Communauté python autour de la documentation française.
+  communauté python autour de la documentation française,
   - `#python-fr <http://irc.lc/freenode/python-fr>`_
-  Communauté python française.
+  communauté python francophone,
   - `#python-doc <http://irc.lc/freenode/python-fr>`_
-  Communauté python autour de la documentation anglaise.
+  communauté python autour de la documentation anglophone ;
 - la `liste traductions AFPy <http://lists.afpy.org/mailman/listinfo/traductions>`_ ;
 - la `liste de diffusion doc-sig
   <https://mail.python.org/mailman/listinfo/doc-sig>`_ ;
@@ -474,7 +475,7 @@ Ressources de traduction
 - le `guide stylistique pour le français de localisation des produits Sun
   <https://web.archive.org/web/20160821182818/http://frenchmozilla.org/FTP/TEMP/guide_stylistique_December05.pdf>`_ donne
   beaucoup de conseils pour éviter une traduction trop mot à mot ;
-- Wikipédia : En allant sur l'article d'un sujet sur la version anglaise
+- Wikipédia. En allant sur l'article d'un sujet sur la version anglaise
   de Wikipédia, puis en basculant sur la version francaise pour voir
   comment le sujet est traduit.
 - `Petites leçons de typographie <https://jacques-andre.fr/faqtypo/lessons.pdf>`_,


### PR DESCRIPTION
Listes et sous-listes sans majuscules au début de chaque ligne et signe de ponctuation correct à la fin de celle-ci.
Le résultat est ici https://github.com/awecx/python-docs-fr/blob/contributing_misc/CONTRIBUTING.rst#ressources-de-traduction.
Je fais une autre PR avec des explications pour les énumérations au sein de la doc.