### PR TITLE
Correction coquille tutorial/controlflow.po

### DIFF
--- a/dict
+++ b/dict
@@ -33,7 +33,6 @@ cpython
 curryfication
 cython
 d'allocateurs
-d'ambigüité
 d'indifférentiabilité
 d'itérateurs
 docstrings

--- a/dict
+++ b/dict
@@ -33,6 +33,7 @@ cpython
 curryfication
 cython
 d'allocateurs
+d'ambigüité
 d'indifférentiabilité
 d'itérateurs
 docstrings

--- a/tutorial/controlflow.po
+++ b/tutorial/controlflow.po
@@ -232,7 +232,7 @@ msgstr ""
 "proche de celle associée à une instruction :keyword:`try` que de celle "
 "associée à une instruction :keyword:`if` : la clause ``else`` d'une "
 "instruction :keyword:`try` s'exécute lorsqu'aucune exception n'est "
-"déclenchée, et celle d'une boucle lorsqu'aucun ``break`` n'intervient. Plus "
+"déclenchée, et celle d'une boucle lorsqu'aucun ``break`` n'intervient. Pour "
 "plus d'informations sur l'instruction :keyword:`!try` et le traitement des "
 "exceptions, consultez :ref:`tut-handling`."
 


### PR DESCRIPTION
J'ai rajouté "d'ambigüité" dans le dict sinon ça ne passait pas avec pospell