### PR TITLE
Encore des changements sur le README.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -108,10 +108,6 @@ Traduction
 
 Vous pouvez commencer à présent commencer à traduire le fichier en respectant les `Conventions`_ du projet.
 
-Pour l'orthographe, une liste blanche de certains termes techniques ou
-de noms propres, comme « Guido », « C99 » ou « sérialisable », est
-stockée dans le fichier « dict » à la racine du projet. Vous pouvez
-bien sûr y ajouter une entrée si nécessaire.
 La commande suivante lance les vérifications nécessaires :
 
 .. code-block:: bash
@@ -240,12 +236,6 @@ Conventions
 -----------
 
 
-- dans les fichiers, ne traduisez pas le contenu des balises comme que
-  ``:ref :...`` et ``:term :...`` ;
-- si vous devez absolument utiliser un mot anglais, mettez-le en *italique*
-  (entouré par des astérisques) ;
-- pour les caractères spéciaux, référez-vous à la section `Caractères spéciaux et typographie`_.
-
 Prototypes et exemples
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -330,17 +320,28 @@ documentation anglaise, si le rythme l'exige. Il faut aussi chercher des
 équivalents français aux termes techniques et aux idiotismes rencontrés, et prendre
 garde aux anglicismes.
 
+Balises
+~~~~~~~
+
+Ne traduisez pas le contenu des balises comme ``:ref :...`` ou ``:term :...``.
+
+
 Glossaire
 ~~~~~~~~~
 
-Afin d'assurer la cohérence de la traduction, voici quelques propositions et
-rappels pour les termes fréquents à traduire.
+Afin d'assurer la cohérence de la traduction, voici quelques 
+termes fréquents déjà traduits. Une liste blanche de noms propres, comme « Guido »,
+« C99 » ou de certains anglicismes comme « sérialisable » ou « implémentation»,
+est stockée dans le fichier « dict » à la racine du projet. Vous pouvez
+y ajouter une entrée si cela est nécessaire.
+Si vous devez *absolument* utiliser un mot anglais, mettez-le en italique
+(entouré par des astérisques).
 
 Pour trouver facilement comment un terme est déjà traduit dans la
 documentation, vous pouvez utiliser `pogrep`_.
 
 ========================== ===============================================
-Terme                      Traduction proposée
+Terme                      Traduction
 ========================== ===============================================
 -like                      -compatible
 abstract data type         type abstrait

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -229,7 +229,7 @@ renvoyée par la commande **à l'exception** des fichiers de :
 Vous pouvez commencer par des tâches faciles comme réviser les entrées
 *fuzzy* pour aider à garder la documentation à jour (trouvez-les à l'aide
 de `make fuzzy`). Une entrée *fuzzy* correspond à une entrée déjà traduite
-mais dont la source en aglais a été remodifiée depuis (correction orthographique,
+mais dont la source en anglais a été remodifiée depuis (correction orthographique,
 changement d'un terme, ajout ou suppression d'une phrase…). Elles sont
 généralement « faciles » à traduire.
 
@@ -240,14 +240,11 @@ idée, et passer ensuite à la traduction de celles qui ne le sont pas encore.
 Conventions
 -----------
 
-Dans les fichiers, ne traduisez pas le contenu des balises telles que
-``:ref :...`` et ``:term :...``.
-
-Si vous devez absolument utiliser un mot anglais, mettez-le en *italique*
-(entouré par des astérisques).
-
-Pour les caractères spéciaux, référez-vous à la section
-`Caractères spéciaux`_.
+- dans les fichiers, ne traduisez pas le contenu des balises telles que
+``:ref :...`` et ``:term :...`` ;
+- si vous devez absolument utiliser un mot anglais, mettez-le en *italique*
+(entouré par des astérisques) ;
+- pour les caractères spéciaux, référez-vous à la section `Caractères spéciaux et typographie`_.
 
 Liens hypertextes
 ~~~~~~~~~~~~~~~~~

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,15 +1,22 @@
 Guide de contribution à la documention via GitHub.
 ==================================================
 
+Instructions
+------------
+
 Prérequis
----------
+~~~~~~~~~
 
 - un compte `Github <https://github.com/join>`_ ;
 - un client ``git`` `Linux <https://git-scm.com/>`_ ou `Windows <https://gitforwindows.org/>`_ ;
 - un éditeur de fichier ``.po`` (comme `Poedit <https://poedit.net/>`_).
 
-Instructions
-------------
+Équipez-vous aussi de quelques outils pour vous aider dans
+votre traduction (voir `Outils utiles pour la traduction`_).
+
+
+*fork* personnel
+~~~~~~~~~~~~~~~
 
 Pour commencer vous aurez besoin de *forker* le dépôt des sources `python-docs-fr
 <https://github.com/python/python-docs-fr>`_ en cliquant sur son bouton
@@ -33,6 +40,10 @@ où vous avez le droit de faire des modifications.
     # ceci permet à *git* de savoir quoi et où est *upstream*
     git remote add upstream https://github.com/python/python-docs-fr.git
 
+
+Réservation d'un fichier
+~~~~~~~~~~~~~~~~~~~~~~~~
+
 Ensuite, vous devez trouver un fichier sur lequel travailler
 (pour vous aiguiller, vous pouvez vous rendre à `Que traduire ?`_ et lire
 les explications concernant `potodo`_ qui vous permettra de voir ce qui a
@@ -44,9 +55,6 @@ en indiquant dans le titre ``Je travaille sur DOSSIER/FICHIER.po``
 (par exemple « Je travaille sur library/sys.po »).
 Ceci permet à `potodo`_ de détecter via l'API Github les fichiers ``.po`` réservés
 dans les tickets et les *pull requests*.
-
-Équipez-vous aussi de quelques outils pour vous aider dans
-votre traduction (voir `Outils utiles pour la traduction`_).
 
 Vous êtes maintenant prêt. Chaque fois que vous commencerez un nouveau fichier,
 suivez cette procédure :
@@ -82,6 +90,7 @@ Ici, remplacez « library/sys.po » par le fichier que vous avez choisi préc�
 
     poedit library/sys.po
 
+
 Ou lancez simplement Poedit puis « Fichier » → « Ouvrir ».
 
 Si vous n'utilisez pas Poedit, vous pouvez utiliser `powrap <https://github.com/JulienPalard/powrap>`_
@@ -92,6 +101,10 @@ ou `powrap library/sys.po` (un fichier en particulier) :
 .. code-block:: bash
 
     powrap -m
+
+
+Traduction
+~~~~~~~~~~
 
 Vous pouvez commencer à présent commencer à traduire le fichier.
 N'oubliez pas de respecter les `Conventions` du projet.
@@ -122,7 +135,11 @@ documentation local :
     make serve
 
 La documentation est publiée l'adresse `<http://localhost:8000/library/sys.html>`_
-(ou tout autre port indiqué par la sortie de la commande précédente).
+(ou tout autre port indiqué par la sortie de la commande précédente). Vous pouvez
+recommencer les étapes de cette section autant de fois que nécessaire.
+
+*pull request*
+~~~~~~~~~~~~~~
 
 C'est le moment de `git add` et `git commit`.
 `git add` place nos modifications dans l'index de Git en
@@ -164,7 +181,7 @@ sur une autre branche) :
 
 .. code-block:: bash
 
-    git checkout library/sys
+    git checkout library-sys
     git pull  # pour rapatrier les modifications que vous auriez acceptées
               # sur l'interface web.
 
@@ -196,7 +213,7 @@ les plus anciennes par l'`équipe de documentation
 <https://www.python.org/dev/peps/pep-8015/#documentation-team>`_.
 
 Que traduire ?
-~~~~~~~~~~~~~~
+--------------
 
 Vous pouvez utiliser `potodo`_, un outil fait pour trouver des fichiers ``po``
 à traduire. Une fois installé, utilisez la commande ``make todo`` dans votre clone
@@ -239,7 +256,6 @@ Il faut « traduire » les liens hypertextes (par exemple s'il s'agit d'un
 lien vers un article de Wikipédia qui possède une traduction).
 Modifiez le lien et sa description dans ce cas.
 Si aucune traduction de la cible n'existe, ne traduisez pas le titre.
-
 
 Utilisation du futur
 ~~~~~~~~~~~~~~~~~~~~
@@ -368,8 +384,8 @@ underscore                 tiret bas, *underscore*
 whitespace                 caractère d'espacement
 ========================== ===============================================
 
-Caractères spéciaux
--------------------
+Caractères spéciaux et typographie
+----------------------------------
 
 La touche de composition
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -550,6 +566,7 @@ Powrap
 | Installez-le à l'aide de *pip* (``pip install powrap``).
 | `Lien vers le dépôt <https://github.com/JulienPalard/powrap>`__
 
+
 Ressources de traduction
 ------------------------
 
@@ -578,6 +595,7 @@ L'utilisation de traducteurs automatiques comme `DeepL https://www.deepl.com/` o
 `reverso https://context.reverso.net/traduction/anglais-francais/` est proscrite.
 Les traductions générées sont très souvent à retravailler, ils ignorent les règles énoncées sur cette
 page et génèrent une documentation au style très « lourd ». 
+
 
 Simplification des diffs git
 ----------------------------
@@ -608,6 +626,7 @@ ce qui suit après vous être assuré que ``~/.local/bin/`` se trouve dans votre
 
 Pas d'inquiétude, cela ne change la façon dont Git voit les changements que sur
 les fichiers de la traduction, sans incidence sur les autres.
+
 
 Maintenance
 -----------
@@ -648,16 +667,16 @@ Trouver les chaînes de caractères *fuzzy*
   make fuzzy
 
 
-Lancer un *build* en local
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+*build* local
+~~~~~~~~~~~~~
 
 .. code-block:: bash
 
   make
 
 
-Lancer un serveur de documentation en local
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Serveur de documentation en local
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -665,8 +684,8 @@ Lancer un serveur de documentation en local
 
 
 
-Synchroniser la traduction avec Transifex
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Synchronisation de la traduction avec Transifex
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Vous aurez besoin de ``transifex-client`` et ``powrap``,
 depuis PyPI.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -328,13 +328,14 @@ Vous devez cependant traduire les balises ``:term:...``, qui font référence à
 un concept ou une primitive Python défini dans le `glossaire <https://docs.python.org/fr/3/glossary.html>`_.
 La syntaxe est ``:term:nom_français<nom_anglais>``. Par exemple, traduisez : 
 
-<https://www.python.org/dev/peps/pep-8015/#documentation-team>`_.
 .. code-block:: bash
+
    :term:`dictionary`
 
 en 
 
 .. code-block:: bash
+   
    :term:`dictionaire <dictionary>`
 
 Comme le glossaire est déjà traduit, il y a forcément une correspondance à chaque

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -323,7 +323,22 @@ garde aux anglicismes.
 Balises
 ~~~~~~~
 
-Ne traduisez pas le contenu des balises comme ``:ref\ :...`` ou ``:term:...``.
+Ne traduisez pas le contenu des balises comme ``:ref:...`` ou ``:class:...``.
+Vous devez cependant traduire les balises ``:term:...``, qui font référence à
+un concept ou une primitive Python défini dans le glossaire. La correspondance
+doit se faire sous la forme ``:term:nom_français<nom_anglais>`` Par exemple,
+traduisez 
+
+.. code-block:: rst
+   :term:`dictionary`
+
+en 
+
+.. code-block:: rst
+   :term:`dictionaire <dictionary>`
+
+Comme le glossaire est déjà traduit, il y a forcément une correspondance à chaque
+terme que vous pouvez rencontrer.
 
 
 Glossaire

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -103,6 +103,23 @@ La commande suivante lance les vérifications nécessaires.
 
     make verifs
 
+Nous pouvons alors compiler la documentation, c'est-à-dire générer les fichiers HTML
+utilisés par le site. Si la commande précédente s'est exécutée sans erreur, la
+compilation ne devrait pas échouer.
+
+.. code-block:: bash
+
+    make
+
+Il faut alors vérifier le rendu de la traduction « en vrai ». Lancez un serveur de
+documentation local :
+
+.. code-block:: bash
+
+    make serve
+
+Pour afficher la documentation, ouvrez l'adresse `<http://localhost:8000/library/sys.html>`_
+(ou tout autre port indiqué par la sortie de la commande précédente).
 
 C'est le moment de `git add` et `git commit`.
 `git add` place nos modifications dans l'index de Git en
@@ -606,8 +623,8 @@ Ceci évite de télécharger tout l'historique (inutile pour générer la
 documentation) mais récupère néanmoins toutes les branches.
 
 
-Fusionner les fichiers *pot* de CPython
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Fusion des fichiers *pot* de CPython
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -628,6 +645,15 @@ Lancer un *build* en local
 .. code-block:: bash
 
   make
+
+
+Lancer un serveur de documentation en local
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  make serve
+
 
 
 Synchroniser la traduction avec Transifex

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -107,7 +107,7 @@ Traduction
 ~~~~~~~~~~
 
 Vous pouvez commencer à présent commencer à traduire le fichier.
-N'oubliez pas de respecter les `Conventions` du projet.
+N'oubliez pas de respecter les `Conventions`_ du projet.
 
 Pour l'orthographe, une liste blanche de certains termes techniques ou
 de noms propres, comme « Guido », « C99 » ou « sérialisable », est
@@ -120,7 +120,7 @@ La commande suivante lance les vérifications nécessaires :
     make verifs
 
 Une fois la traduction finie, il faut compiler la documentation, c'est-à-dire générer les fichiers HTML
-utilisés par le site pour les relire. Si la commande précédente s'est exécutée sans erreur, la
+affichés par le site, pour les relire. Si la commande précédente s'est exécutée sans erreur, la
 compilation ne devrait pas échouer.
 
 .. code-block:: bash
@@ -231,7 +231,7 @@ Vous pouvez commencer par des tâches faciles comme réviser les entrées
 de `make fuzzy`). Une entrée *fuzzy* correspond à une entrée déjà traduite
 mais dont la source en anglais a été remodifiée depuis (correction orthographique,
 changement d'un terme, ajout ou suppression d'une phrase…). Elles sont
-généralement « faciles » à traduire.
+généralement « plus faciles » à traduire.
 
 Vous pouvez également relire des entrées déjà traduites pour vous faire une
 idée, et passer ensuite à la traduction de celles qui ne le sont pas encore.
@@ -241,9 +241,9 @@ Conventions
 -----------
 
 - dans les fichiers, ne traduisez pas le contenu des balises telles que
-``:ref :...`` et ``:term :...`` ;
+  ``:ref :...`` et ``:term :...`` ;
 - si vous devez absolument utiliser un mot anglais, mettez-le en *italique*
-(entouré par des astérisques) ;
+  (entouré par des astérisques) ;
 - pour les caractères spéciaux, référez-vous à la section `Caractères spéciaux et typographie`_.
 
 Liens hypertextes
@@ -621,7 +621,7 @@ ce qui suit après vous être assuré que ``~/.local/bin/`` se trouve dans votre
     git config diff.podiff.textconv podiff
 
 
-Pas d'inquiétude, cela ne change la façon dont Git voit les changements que sur
+Pas d'inquiétude, cela ne change la façon dont Git affiche les changements que sur
 les fichiers de la traduction, sans incidence sur les autres.
 
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -45,9 +45,9 @@ Réservation d'un fichier
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Ensuite, vous devez trouver un fichier sur lequel travailler
-(pour vous aiguiller, vous pouvez vous rendre à `Que traduire ?`_ et lire
-les explications concernant `potodo`_ qui vous permettra de voir ce qui a
-déjà été traduit et ce qui ne l'a pas été).
+(pour vous aiguiller, lisez la section `Que traduire ?`_). Nous vous conseillons
+de choisir, si possible, un fichier traitant d'un sujet que vous maitrisez, cela
+vous aidera grandement à produire une traduction de bonne qualité.
 
 Une fois que vous avez choisi un fichier sur lequel travailler, veuillez
 ouvrir un `ticket sur Github <https://github.com/python/python-docs-fr/issues>`_

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -235,7 +235,6 @@ idée, et passer ensuite à la traduction de celles qui ne le sont pas encore.
 Conventions
 -----------
 
-
 Prototypes et exemples
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -266,7 +265,6 @@ mais pas en
        resultat = function_de_la_biliotheque(argument_nomme=...)
        ...
 
-
 Liens hypertextes
 ~~~~~~~~~~~~~~~~~
 
@@ -274,6 +272,29 @@ Il faut « traduire » les liens hypertextes (par exemple s'il s'agit d'un
 lien vers un article de Wikipédia qui possède une traduction).
 Modifiez le lien et sa description dans ce cas.
 Si aucune traduction de la cible n'existe, ne traduisez pas le titre.
+
+Balises
+~~~~~~~
+
+Ne traduisez pas le contenu des balises comme ``:ref:...`` ou ``:class:...``.
+Vous devez cependant traduire les balises ``:term:...``, qui font référence à
+un concept ou une primitive Python défini dans le `glossaire <https://docs.python.org/fr/3/glossary.html>`_.
+La syntaxe est ``:term:nom_français<nom_anglais>``. Par exemple, traduisez
+``:term:`dictionary``` en  ``:term:`dictionaire <dictionary>```
+
+Comme le glossaire est déjà traduit, il y a forcément une correspondance à chaque
+terme que vous pouvez rencontrer.
+
+Style
+~~~~~
+
+Une bonne traduction est une traduction qui transcrit fidèlement l'idée originelle
+en français, sans rien ajouter ni enlever au fond, tout en restant claire, concise et
+agréable à lire. Les traductions mot-à-mot sont à proscrire et il est permis — même
+conseillé — d'intervertir des propositions ou de réarranger des phrases de la
+documentation anglaise, si le rythme l'exige. Il faut aussi chercher des
+équivalents français aux termes techniques et aux idiotismes rencontrés, et prendre
+garde aux anglicismes.
 
 Utilisation du futur
 ~~~~~~~~~~~~~~~~~~~~
@@ -308,30 +329,6 @@ Utilisation du masculin
 Dans un souci de lisibilité et en accord avec la préconisation de
 l'Académie française, nous utilisons le masculin pour indiquer un
 genre neutre. Par exemple : l'utilisateur ou le lecteur.
-
-Style
-~~~~~
-
-Une bonne traduction est une traduction qui transcrit fidèlement l'idée originelle
-en français, sans rien ajouter ni enlever au fond, tout en restant claire, concise et
-agréable à lire. Les traductions mot-à-mot sont à proscrire et il est permis — même
-conseillé — d'intervertir des propositions ou de réarranger des phrases de la
-documentation anglaise, si le rythme l'exige. Il faut aussi chercher des
-équivalents français aux termes techniques et aux idiotismes rencontrés, et prendre
-garde aux anglicismes.
-
-Balises
-~~~~~~~
-
-Ne traduisez pas le contenu des balises comme ``:ref:...`` ou ``:class:...``.
-Vous devez cependant traduire les balises ``:term:...``, qui font référence à
-un concept ou une primitive Python défini dans le `glossaire <https://docs.python.org/fr/3/glossary.html>`_.
-La syntaxe est ``:term:nom_français<nom_anglais>``. Par exemple, traduisez
-``:term:\`dictionary\``` en  ``:term:`dictionaire <dictionary>```
-
-Comme le glossaire est déjà traduit, il y a forcément une correspondance à chaque
-terme que vous pouvez rencontrer.
-
 
 Glossaire
 ~~~~~~~~~
@@ -384,8 +381,8 @@ i.e.                       c.-à-d. (on n'utilise pas l'anglicisme « i.e. »,
 identifier                 identifiant
 immutable                  immuable
 import                     importation
-index                      indice (en particulier quand on parle de chaînes de
-                           caractères)
+index                      indice (en particulier quand on parle de chaînes
+                           de caractères)
 installer                  installateur
 interpreter                interpréteur
 library                    bibliothèque
@@ -409,10 +406,11 @@ simple quote               guillemet simple
 socket                     connecteur ou interface de connexion
 statement                  instruction
 subprocess                 sous-processus
-support                    prendre en charge, implémenter (« supporter » n'a
-                           pas le même sens en français)
+support                    prendre en charge, implémenter (« supporter »
+                           n'a pas le même sens en français)
 specify                    définir, préciser (plutôt que « spécifier »)
-typically                  normalement, habituellement, comme d'habitude (plutôt que « typiquement »)
+typically                  normalement, habituellement, comme d'habitude
+                           (plutôt que « typiquement »)
 thread                     fil d'exécution
 traceback                  trace d'appels, trace de pile
 tuple                      n-uplet

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -272,6 +272,9 @@ Il faut « traduire » les liens hypertextes (par exemple s'il s'agit d'un
 lien vers un article de Wikipédia qui possède une traduction).
 Modifiez le lien et sa description dans ce cas.
 Si aucune traduction de la cible n'existe, ne traduisez pas le titre.
+Par exemple vous pouvez traduire ``Conway's Game of Life <https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life>``
+en    ``https://fr.wikipedia.org/wiki/Jeu_de_la_vie``
+
 
 Balises
 ~~~~~~~
@@ -280,7 +283,7 @@ Ne traduisez pas le contenu des balises comme ``:ref:...`` ou ``:class:...``.
 Vous devez cependant traduire les balises ``:term:...``, qui font référence à
 un concept ou une primitive Python défini dans le `glossaire <https://docs.python.org/fr/3/glossary.html>`_.
 La syntaxe est ``:term:nom_français<nom_anglais>``. Par exemple, traduisez
-``:term:`dictionary``` en  ``:term:`dictionaire <dictionary>```
+``:term:`dictionary``` en  ``:term:`dictionaire <dictionary>```.
 
 Comme le glossaire est déjà traduit, il y a forcément une correspondance à chaque
 terme que vous pouvez rencontrer.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -325,16 +325,16 @@ Balises
 
 Ne traduisez pas le contenu des balises comme ``:ref:...`` ou ``:class:...``.
 Vous devez cependant traduire les balises ``:term:...``, qui font référence à
-un concept ou une primitive Python défini dans le glossaire. La correspondance
-doit se faire sous la forme ``:term:nom_français<nom_anglais>`` Par exemple,
-traduisez 
+un concept ou une primitive Python défini dans le `glossaire <https://docs.python.org/fr/3/glossary.html>`_.
+La syntaxe est ``:term:nom_français<nom_anglais>``. Par exemple, traduisez : 
 
-.. code-block:: rst
+<https://www.python.org/dev/peps/pep-8015/#documentation-team>`_.
+.. code-block:: bash
    :term:`dictionary`
 
 en 
 
-.. code-block:: rst
+.. code-block:: bash
    :term:`dictionaire <dictionary>`
 
 Comme le glossaire est déjà traduit, il y a forcément une correspondance à chaque

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -326,17 +326,8 @@ Balises
 Ne traduisez pas le contenu des balises comme ``:ref:...`` ou ``:class:...``.
 Vous devez cependant traduire les balises ``:term:...``, qui font référence à
 un concept ou une primitive Python défini dans le `glossaire <https://docs.python.org/fr/3/glossary.html>`_.
-La syntaxe est ``:term:nom_français<nom_anglais>``. Par exemple, traduisez : 
-
-.. code-block:: bash
-
-   :term:`dictionary`
-
-en 
-
-.. code-block:: bash
-   
-   :term:`dictionaire <dictionary>`
+La syntaxe est ``:term:nom_français<nom_anglais>``. Par exemple, traduisez
+``:term:\`dictionary\``` en  ``:term:`dictionaire <dictionary>```
 
 Comme le glossaire est déjà traduit, il y a forcément une correspondance à chaque
 terme que vous pouvez rencontrer.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -239,11 +239,43 @@ idée, et passer ensuite à la traduction de celles qui ne le sont pas encore.
 Conventions
 -----------
 
-- dans les fichiers, ne traduisez pas le contenu des balises telles que
+
+- dans les fichiers, ne traduisez pas le contenu des balises comme que
   ``:ref :...`` et ``:term :...`` ;
 - si vous devez absolument utiliser un mot anglais, mettez-le en *italique*
   (entouré par des astérisques) ;
 - pour les caractères spéciaux, référez-vous à la section `Caractères spéciaux et typographie`_.
+
+Prototypes et exemples
+~~~~~~~~~~~~~~~~~~~~~~
+
+Il ne faut pas traduire le nom des paramètres d'une méthode ou d'une fonction mais les
+laisser tels quel entourés d'astérisques.
+Si la documentation contient des exemples, vous *pouvez* traduire les noms de variables
+utilisés, en prenant garde d'être cohérent. Vous pouvez ainsi traduire :
+
+.. code-block:: python
+
+    def sample_function():
+       result = stdlib_function(keyword_arg=...)
+       ...
+
+en
+
+.. code-block:: python
+
+    def fonction_exemple():
+       resultat = stdlib_function(keyword_arg=...)
+       ...
+
+mais pas en 
+
+.. code-block:: python
+
+    def fonction_exemple():
+       resultat = function_de_la_biliotheque(argument_nomme=...)
+       ...
+
 
 Liens hypertextes
 ~~~~~~~~~~~~~~~~~

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -323,7 +323,7 @@ garde aux anglicismes.
 Balises
 ~~~~~~~
 
-Ne traduisez pas le contenu des balises comme ``:ref :...`` ou ``:term :...``.
+Ne traduisez pas le contenu des balises comme ``:ref\ :...`` ou ``:term:...``.
 
 
 Glossaire

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,5 +1,5 @@
-Guide de contribution à la documention via GitHub.
-==================================================
+Guide de contribution à la documention via GitHub
+=================================================
 
 Instructions
 ------------
@@ -20,7 +20,7 @@ votre traduction (voir `Outils utiles pour la traduction`_).
 
 Pour commencer vous aurez besoin de *forker* le dépôt des sources `python-docs-fr
 <https://github.com/python/python-docs-fr>`_ en cliquant sur son bouton
-``Fork``. Ceci crée une copie du projet sur votre compte Github : un endroit
+``Fork``. Ceci crée une copie du projet sur votre compte Github, c'est un endroit
 où vous avez le droit de faire des modifications.
 
 Étape par étape :
@@ -106,8 +106,7 @@ ou `powrap library/sys.po` (un fichier en particulier) :
 Traduction
 ~~~~~~~~~~
 
-Vous pouvez commencer à présent commencer à traduire le fichier.
-N'oubliez pas de respecter les `Conventions`_ du projet.
+Vous pouvez commencer à présent commencer à traduire le fichier en respectant les `Conventions`_ du projet.
 
 Pour l'orthographe, une liste blanche de certains termes techniques ou
 de noms propres, comme « Guido », « C99 » ou « sérialisable », est
@@ -160,7 +159,7 @@ Puis on propage les modifications dans le dépôt local avec un commit.
 Poussez ensuite vos modifications sur votre fork Github.
 Le -u n'est utile qu'une fois pour que votre client git se souvienne que cette
 branche est liée à votre fork Github (et donc que vos futurs `git pull` et
-`git push` sachent quoi tirer)
+`git push` sachent quoi tirer).
 
 .. code-block:: bash
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -272,8 +272,8 @@ Il faut « traduire » les liens hypertextes (par exemple s'il s'agit d'un
 lien vers un article de Wikipédia qui possède une traduction).
 Modifiez le lien et sa description dans ce cas.
 Si aucune traduction de la cible n'existe, ne traduisez pas le titre.
-Par exemple vous pouvez traduire ``Conway's Game of Life <https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life>``
-en    ``https://fr.wikipedia.org/wiki/Jeu_de_la_vie``
+Par exemple vous pouvez traduire ```Conway's Game of Life <https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life>`_``
+en ```Jeu de la vie <https://fr.wikipedia.org/wiki/Jeu_de_la_vie>`_``.
 
 
 Balises

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -238,15 +238,16 @@ Conventions
 Prototypes et exemples
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Il ne faut pas traduire le nom des paramètres d'une méthode ou d'une fonction mais les
-laisser tels quel entourés d'astérisques.
-Si la documentation contient des exemples, vous *pouvez* traduire les noms de variables
+Il ne faut pas traduire le nom des éléments de la bibliothèque standard (noms
+de fonctions, paramètres de ces fonctions, constantes etc.) mais les laisser
+tels quel, entourés d'astérisques dans les blocs de texte.
+Si la documentation contient des exemples, vous *pouvez* traduire les noms
 utilisés, en prenant garde d'être cohérent. Vous pouvez ainsi traduire :
 
 .. code-block:: python
 
     def sample_function():
-       result = stdlib_function(keyword_arg=...)
+       result = thread.join(timeout=...)
        ...
 
 en
@@ -254,7 +255,7 @@ en
 .. code-block:: python
 
     def fonction_exemple():
-       resultat = stdlib_function(keyword_arg=...)
+       resultat = thread.join(timeout=...)
        ...
 
 mais pas en 
@@ -262,18 +263,18 @@ mais pas en
 .. code-block:: python
 
     def fonction_exemple():
-       resultat = function_de_la_biliotheque(argument_nomme=...)
+       resultat = fildexécution.attendre(délai=...)
        ...
 
 Liens hypertextes
 ~~~~~~~~~~~~~~~~~
 
-Il faut « traduire » les liens hypertextes (par exemple s'il s'agit d'un
-lien vers un article de Wikipédia qui possède une traduction).
-Modifiez le lien et sa description dans ce cas.
-Si aucune traduction de la cible n'existe, ne traduisez pas le titre.
-Par exemple vous pouvez traduire ```Conway's Game of Life <https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life>`_``
-en ```Jeu de la vie <https://fr.wikipedia.org/wiki/Jeu_de_la_vie>`_``.
+Il faut transformer les liens hypertextes qui redirigent vers une page dont il
+existe une version française (c'est notamment très souvent le cas pour les
+articles de Wikipédia). Modifiez le lien *et* sa description dans ce cas.
+Si aucune traduction de la cible n'existe, ne traduisez pas la description.
+Par exemple, ```Conway's Game of Life <https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life>`_``
+doit devenir ```Jeu de la vie <https://fr.wikipedia.org/wiki/Jeu_de_la_vie>`_``.
 
 
 Balises

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -93,32 +93,35 @@ ou `powrap library/sys.po` (un fichier en particulier) :
 
     powrap -m
 
+Vous pouvez commencer à présent commencer à traduire le fichier.
+N'oubliez pas de respecter les `Conventions` du projet.
+
 Pour l'orthographe, une liste blanche de certains termes techniques ou
 de noms propres, comme « Guido », « C99 » ou « sérialisable », est
 stockée dans le fichier « dict » à la racine du projet. Vous pouvez
 bien sûr y ajouter une entrée si nécessaire.
-La commande suivante lance les vérifications nécessaires.
+La commande suivante lance les vérifications nécessaires :
 
 .. code-block:: bash
 
     make verifs
 
-Nous pouvons alors compiler la documentation, c'est-à-dire générer les fichiers HTML
-utilisés par le site. Si la commande précédente s'est exécutée sans erreur, la
+Une fois la traduction finie, il faut compiler la documentation, c'est-à-dire générer les fichiers HTML
+utilisés par le site pour les relire. Si la commande précédente s'est exécutée sans erreur, la
 compilation ne devrait pas échouer.
 
 .. code-block:: bash
 
     make
 
-Il faut alors vérifier le rendu de la traduction « en vrai ». Lancez un serveur de
+Vérifiez alors le rendu de la traduction « en vrai ». Lancez un serveur de
 documentation local :
 
 .. code-block:: bash
 
     make serve
 
-Pour afficher la documentation, ouvrez l'adresse `<http://localhost:8000/library/sys.html>`_
+La documentation est publiée l'adresse `<http://localhost:8000/library/sys.html>`_
 (ou tout autre port indiqué par la sortie de la commande précédente).
 
 C'est le moment de `git add` et `git commit`.
@@ -196,7 +199,7 @@ Que traduire ?
 ~~~~~~~~~~~~~~
 
 Vous pouvez utiliser `potodo`_, un outil fait pour trouver des fichiers ``po``
-à traduire. Une fois installé, utilisez la commande ``potodo`` dans votre clone
+à traduire. Une fois installé, utilisez la commande ``make todo`` dans votre clone
 local.
 
 Vous pouvez choisir n'importe quel fichier non réservé dans la liste
@@ -207,18 +210,18 @@ renvoyée par la commande **à l'exception** des fichiers de :
 - ``distutils/`` et ``install/`` car ces pages seront bientôt obsolètes. 
 
 Vous pouvez commencer par des tâches faciles comme réviser les entrées
-*fuzzy* pour aider à garder la documentation à jour (trouvez les entrées
-*fuzzy* l'aide de `make fuzzy`).
+*fuzzy* pour aider à garder la documentation à jour (trouvez-les à l'aide
+de `make fuzzy`). Une entrée *fuzzy* correspond à une entrée déjà traduite
+mais dont la source en aglais a été remodifiée depuis (correction orthographique,
+changement d'un terme, ajout ou suppression d'une phrase…). Elles sont
+généralement « faciles » à traduire.
 
 Vous pouvez également relire des entrées déjà traduites pour vous faire une
 idée, et passer ensuite à la traduction de celles qui ne le sont pas encore.
-Vous pouvez les trouver à l'aide de `make todo`…
 
-Vous pouvez aussi « traduire » des liens hypertextes
-(par exemple s'il s'agit d'un lien vers un article de Wikipédia qui possède une
-traduction).
-Modifiez le lien et sa description dans ce cas.
-Si aucune traduction de la cible n'existe, ne traduisez pas le titre.
+
+Conventions
+-----------
 
 Dans les fichiers, ne traduisez pas le contenu des balises telles que
 ``:ref :...`` et ``:term :...``.
@@ -229,8 +232,14 @@ Si vous devez absolument utiliser un mot anglais, mettez-le en *italique*
 Pour les caractères spéciaux, référez-vous à la section
 `Caractères spéciaux`_.
 
-Conseils
---------
+Liens hypertextes
+~~~~~~~~~~~~~~~~~
+
+Il faut « traduire » les liens hypertextes (par exemple s'il s'agit d'un
+lien vers un article de Wikipédia qui possède une traduction).
+Modifiez le lien et sa description dans ce cas.
+Si aucune traduction de la cible n'existe, ne traduisez pas le titre.
+
 
 Utilisation du futur
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- découpage plus granulaire de la section « Instructions » ;
- instructions pour le « make serve » ;
- `make todo` plutôt que `potodo` (remonté par @deronnax sur #1289) ;
- autres modifications mineures.

Les changements sont visibles [ici](https://github.com/awecx/python-docs-fr/blob/contributing_5/CONTRIBUTING.rst).