### PR TITLE
Forward porting from 3.8.

### DIFF
--- a/c-api/call.po
+++ b/c-api/call.po
@@ -176,7 +176,7 @@ msgstr ""
 
 #: /home/mdk/clones/python/cpython/Doc/c-api/call.rst:121
 msgid "Recursion Control"
-msgstr ""
+msgstr "Contrôle de la récursion"
 
 #: /home/mdk/clones/python/cpython/Doc/c-api/call.rst:123
 msgid ""
@@ -268,7 +268,7 @@ msgstr ""
 
 #: /home/mdk/clones/python/cpython/Doc/c-api/call.rst:195
 msgid "Function"
-msgstr ""
+msgstr "Fonction"
 
 #: /home/mdk/clones/python/cpython/Doc/c-api/call.rst:195
 msgid "callable"
@@ -346,7 +346,7 @@ msgstr ""
 #: /home/mdk/clones/python/cpython/Doc/c-api/call.rst:205
 #: /home/mdk/clones/python/cpython/Doc/c-api/call.rst:207
 msgid "format"
-msgstr ""
+msgstr "format"
 
 #: /home/mdk/clones/python/cpython/Doc/c-api/call.rst:207
 msgid ":c:func:`PyObject_CallMethod`"
@@ -410,6 +410,8 @@ msgid ""
 "Call a callable Python object *callable*, with arguments given by the tuple "
 "*args*, and named arguments given by the dictionary *kwargs*."
 msgstr ""
+"Appelle un objet Python appelable *callable*, avec des arguments donnés par "
+"le tuple *args*, et des arguments nommés donnés par le dictionnaire *kwargs*."
 
 #: /home/mdk/clones/python/cpython/Doc/c-api/call.rst:230
 msgid ""
@@ -439,6 +441,7 @@ msgid ""
 "This is the equivalent of the Python expression: ``callable(*args, "
 "**kwargs)``."
 msgstr ""
+"Ceci est l'équivalent de l'expression Python : ``callable(*args, **kwargs)``."
 
 #: /home/mdk/clones/python/cpython/Doc/c-api/call.rst:242
 msgid ""
@@ -461,7 +464,7 @@ msgstr ""
 #: /home/mdk/clones/python/cpython/Doc/c-api/call.rst:272
 #: /home/mdk/clones/python/cpython/Doc/c-api/call.rst:284
 msgid "This is the equivalent of the Python expression: ``callable(*args)``."
-msgstr ""
+msgstr "Ceci est l'équivalent de l'expression Python : ``callable(*args)``."
 
 #: /home/mdk/clones/python/cpython/Doc/c-api/call.rst:277
 msgid ""
@@ -591,3 +594,5 @@ msgid ""
 "Determine if the object *o* is callable.  Return ``1`` if the object is "
 "callable and ``0`` otherwise.  This function always succeeds."
 msgstr ""
+"Détermine si l'objet *o* est appelable. Renvoie ``1`` si c'est le cas, et "
+"``0`` sinon. Cette fonction réussit toujours."

--- a/c-api/memory.po
+++ b/c-api/memory.po
@@ -488,7 +488,7 @@ msgstr ""
 
 #: ../Doc/c-api/memory.rst:368 ../Doc/c-api/memory.rst:513
 msgid "Field"
-msgstr ""
+msgstr "Champ"
 
 #: ../Doc/c-api/memory.rst:368 ../Doc/c-api/memory.rst:513
 msgid "Meaning"

--- a/c-api/structures.po
+++ b/c-api/structures.po
@@ -143,7 +143,7 @@ msgstr ""
 #: ../Doc/c-api/structures.rst:139 ../Doc/c-api/structures.rst:279
 #: ../Doc/c-api/structures.rst:345
 msgid "Field"
-msgstr ""
+msgstr "Champ"
 
 #: ../Doc/c-api/structures.rst:139 ../Doc/c-api/structures.rst:279
 #: ../Doc/c-api/structures.rst:345

--- a/c-api/tuple.po
+++ b/c-api/tuple.po
@@ -165,7 +165,7 @@ msgstr ""
 
 #: ../Doc/c-api/tuple.rst:151 ../Doc/c-api/tuple.rst:174
 msgid "Field"
-msgstr ""
+msgstr "Champ"
 
 #: ../Doc/c-api/tuple.rst:151 ../Doc/c-api/tuple.rst:174
 msgid "C Type"

--- a/dict
+++ b/dict
@@ -16,6 +16,7 @@ boguer
 c++
 c-
 c/c++
+C89
 c99
 chacha20
 cadriciel

--- a/library/datetime.po
+++ b/library/datetime.po
@@ -2210,6 +2210,13 @@ msgid ""
 "replace(tzinfo=timezone.utc)`` to make it aware, at which point you can use :"
 "meth:`.datetime.timetuple`."
 msgstr ""
+"Comme les objets ``datetime`` naïfs sont traités par de nombreuses méthodes "
+"``datetime`` comme des heures locales, il est préférable d'utiliser les "
+"``datetime`` avisés pour représenter les heures en UTC ; par conséquent, "
+"l'utilisation de ``utcfromtimetuple`` peut donner des résultats trompeurs. "
+"Si vous disposez d'une ``datetime`` naïve représentant l'heure UTC, utilisez "
+"``datetime.replace(tzinfo=timezone.utc)`` pour la rendre avisée, puis vous "
+"pouvez utiliser :meth:`.datetime.timetuple`."
 
 #: ../Doc/library/datetime.rst:1345
 #, fuzzy
@@ -3416,12 +3423,17 @@ msgid ""
 "datetime` object from a string representing a date and time and a "
 "corresponding format string."
 msgstr ""
+"Inversement, la méthode de classe :meth:`datetime.strptime` crée un objet :"
+"class:`.datetime` à partir d'une chaîne représentant une date et une heure, "
+"et une chaîne de format correspondante."
 
 #: ../Doc/library/datetime.rst:2279
 msgid ""
 "The table below provides a high-level comparison of :meth:`strftime` versus :"
 "meth:`strptime`:"
 msgstr ""
+"Le tableau ci-dessous fournit une comparaison de haut niveau entre :meth:"
+"`strftime` et :meth:`strptime` :"
 
 #: ../Doc/library/datetime.rst:2283
 #, fuzzy
@@ -3435,20 +3447,22 @@ msgstr "``str(t)``"
 
 #: ../Doc/library/datetime.rst:2285
 msgid "Usage"
-msgstr ""
+msgstr "Utilisation"
 
 #: ../Doc/library/datetime.rst:2285
 msgid "Convert object to a string according to a given format"
-msgstr ""
+msgstr "Convertit un objet en une chaîne de caractères selon un format donné"
 
 #: ../Doc/library/datetime.rst:2285
 msgid ""
 "Parse a string into a :class:`.datetime` object given a corresponding format"
 msgstr ""
+"Analyse une chaîne de caractères dans un objet :class:`.datetime` en "
+"fonction du format de correspondance donné"
 
 #: ../Doc/library/datetime.rst:2287
 msgid "Type of method"
-msgstr ""
+msgstr "Type de méthode"
 
 #: ../Doc/library/datetime.rst:2287
 #, fuzzy
@@ -3457,11 +3471,11 @@ msgstr "Méthodes de l'instance :"
 
 #: ../Doc/library/datetime.rst:2287
 msgid "Class method"
-msgstr ""
+msgstr "Méthode de classe"
 
 #: ../Doc/library/datetime.rst:2289
 msgid "Method of"
-msgstr ""
+msgstr "Méthode de"
 
 #: ../Doc/library/datetime.rst:2289
 #, fuzzy
@@ -3475,7 +3489,7 @@ msgstr "Objets :class:`.datetime`"
 
 #: ../Doc/library/datetime.rst:2291
 msgid "Signature"
-msgstr ""
+msgstr "Signature"
 
 #: ../Doc/library/datetime.rst:2291
 #, fuzzy
@@ -3484,7 +3498,7 @@ msgstr "``str(t)``"
 
 #: ../Doc/library/datetime.rst:2291
 msgid "``strptime(date_string, format)``"
-msgstr ""
+msgstr "``strptime(date_string, format)``"
 
 #: ../Doc/library/datetime.rst:2296
 #, fuzzy
@@ -3880,6 +3894,9 @@ msgid ""
 "Several additional directives not required by the C89 standard are included "
 "for convenience. These parameters all correspond to ISO 8601 date values."
 msgstr ""
+"Plusieurs directives supplémentaires non requises par la norme C89 sont "
+"incluses pour des raisons de commodité. Ces paramètres correspondent tous "
+"aux valeurs de date de la norme ISO 8601."
 
 #: ../Doc/library/datetime.rst:2407
 msgid "``%G``"
@@ -3966,7 +3983,7 @@ msgstr "``%G``, ``%u`` et ``%V`` ont été ajoutés."
 
 #: ../Doc/library/datetime.rst:2436
 msgid "Technical Detail"
-msgstr ""
+msgstr "Détail technique"
 
 #: ../Doc/library/datetime.rst:2438
 #, fuzzy
@@ -3995,6 +4012,7 @@ msgstr ""
 #: ../Doc/library/datetime.rst:2446
 msgid "Using ``datetime.strptime(date_string, format)`` is equivalent to::"
 msgstr ""
+"L'utilisation de ``datetime.strptime(date_string, format)`` équivaut à ::"
 
 #: ../Doc/library/datetime.rst:2450
 msgid ""
@@ -4002,6 +4020,9 @@ msgid ""
 "information, which are supported in ``datetime.strptime`` but are discarded "
 "by ``time.strptime``."
 msgstr ""
+"sauf lorsque le format inclut des composantes de sous-secondes ou des "
+"informations de décalage de fuseau horaire, qui sont prises en charge dans "
+"``datetime.strptime`` mais pas par ``time.strptime``."
 
 #: ../Doc/library/datetime.rst:2454
 #, fuzzy

--- a/library/devmode.po
+++ b/library/devmode.po
@@ -53,19 +53,19 @@ msgstr ""
 
 #: /home/mdk/clones/python/cpython/Doc/library/devmode.rst:29
 msgid ":exc:`DeprecationWarning`"
-msgstr ""
+msgstr ":exc:`DeprecationWarning`"
 
 #: /home/mdk/clones/python/cpython/Doc/library/devmode.rst:30
 msgid ":exc:`ImportWarning`"
-msgstr ""
+msgstr ":exc:`ImportWarning`"
 
 #: /home/mdk/clones/python/cpython/Doc/library/devmode.rst:31
 msgid ":exc:`PendingDeprecationWarning`"
-msgstr ""
+msgstr ":exc:`PendingDeprecationWarning`"
 
 #: /home/mdk/clones/python/cpython/Doc/library/devmode.rst:32
 msgid ":exc:`ResourceWarning`"
-msgstr ""
+msgstr ":exc:`ResourceWarning`"
 
 #: /home/mdk/clones/python/cpython/Doc/library/devmode.rst:34
 msgid ""
@@ -171,6 +171,8 @@ msgid ""
 "Set the :attr:`~sys.flags.dev_mode` attribute of :attr:`sys.flags` to "
 "``True``."
 msgstr ""
+"Définit l'attribut :attr:`~sys.flags.dev_mode` de :attr:`sys.flags` à "
+"``True``"
 
 #: /home/mdk/clones/python/cpython/Doc/library/devmode.rst:85
 msgid ""

--- a/library/logging.config.po
+++ b/library/logging.config.po
@@ -29,11 +29,11 @@ msgstr ""
 
 #: ../Doc/library/logging.config.rst:17
 msgid ":ref:`Basic Tutorial <logging-basic-tutorial>`"
-msgstr ""
+msgstr ":ref:`Tutoriel basique <logging-basic-tutorial>`"
 
 #: ../Doc/library/logging.config.rst:18
 msgid ":ref:`Advanced Tutorial <logging-advanced-tutorial>`"
-msgstr ""
+msgstr ":ref:`Tutoriel avancé <logging-advanced-tutorial>`"
 
 #: ../Doc/library/logging.config.rst:19
 #, fuzzy

--- a/library/logging.handlers.po
+++ b/library/logging.handlers.po
@@ -29,11 +29,11 @@ msgstr ""
 
 #: ../Doc/library/logging.handlers.rst:17
 msgid ":ref:`Basic Tutorial <logging-basic-tutorial>`"
-msgstr ""
+msgstr ":ref:`Tutoriel basique <logging-basic-tutorial>`"
 
 #: ../Doc/library/logging.handlers.rst:18
 msgid ":ref:`Advanced Tutorial <logging-advanced-tutorial>`"
-msgstr ""
+msgstr ":ref:`Tutoriel avancé <logging-advanced-tutorial>`"
 
 #: ../Doc/library/logging.handlers.rst:19
 #, fuzzy

--- a/library/msilib.po
+++ b/library/msilib.po
@@ -458,7 +458,7 @@ msgstr ""
 
 #: ../Doc/library/msilib.rst:414
 msgid "Features"
-msgstr ""
+msgstr "Caractéristiques"
 
 #: ../Doc/library/msilib.rst:419
 msgid ""

--- a/library/multiprocessing.shared_memory.po
+++ b/library/multiprocessing.shared_memory.po
@@ -19,10 +19,12 @@ msgid ""
 ":mod:`multiprocessing.shared_memory` ---  Provides shared memory for direct "
 "access across processes"
 msgstr ""
+":mod:`multiprocessing.shared_memory` — Mémoire partagée en accès direct "
+"depuis plusieurs processus"
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:7
 msgid "**Source code:** :source:`Lib/multiprocessing/shared_memory.py`"
-msgstr ""
+msgstr "**Code source :** :source:`Lib/multiprocessing/shared_memory.py`"
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:18
 msgid ""
@@ -34,6 +36,14 @@ msgid ""
 "`SharedMemoryManager`, is also provided in the ``multiprocessing.managers`` "
 "module."
 msgstr ""
+"Ce module fournit une classe, :class:`SharedMemory`, pour l'allocation et la "
+"gestion de mémoire partagée entre un ou plusieurs processus sur une machine "
+"à plusieurs cœurs ou à multiprocesseurs (architecture *symmetric "
+"multiprocessor* ou SMP). Pour faciliter la gestion du cycle de vie de la "
+"mémoire partagée, tout particulièrement entre plusieurs processus, le module "
+"``multiprocessing.managers`` fournit aussi la classe :class:"
+"`~multiprocessing.managers.SharedMemoryManager`, sous-classe de :class:"
+"`BaseManager`."
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:26
 msgid ""
@@ -49,6 +59,17 @@ msgid ""
 "via disk or socket or other communications requiring the serialization/"
 "deserialization and copying of data."
 msgstr ""
+"Dans ce module, il faut entendre « mémoire partagée » au sens de « blocs de "
+"mémoire partagée à la mode System V » (même si l'implémentation peut "
+"différer), et non au sens de « mémoire distribuée ». Ce type de mémoire "
+"partagée permet à plusieurs processus d'écrire dans une zone commune (ou "
+"« partagée ») de la mémoire vive. Normalement, les processus n'ont accès "
+"qu'à leur propre espace mémoire ; la mémoire partagée permet justement le "
+"partage de données entre des processus, ce qui leur évite d'avoir à "
+"s'envoyer ces données par message. Échanger des données par mémoire partagée "
+"peut amener des gains de performance substantiels par rapport aux échanges "
+"via le disque dur, des connecteurs ou d'autres canaux qui nécessitent de "
+"sérialiser et de désérialiser les données."
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:41
 msgid ""
@@ -58,6 +79,11 @@ msgid ""
 "different process can attach to that same shared memory block using that "
 "same name."
 msgstr ""
+"Crée un nouveau bloc de mémoire partagée ou enregistre un bloc déjà "
+"existant. Un nom unique doit être donné à chaque bloc de mémoire partagée ; "
+"ainsi, un processus peut créer un nouveau bloc de mémoire partagée avec un "
+"nom fixé et un autre processus peut enregistrer le même bloc, à partir de "
+"son nom."
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:47
 msgid ""
@@ -68,6 +94,12 @@ msgid ""
 "block is no longer needed by any process, the :meth:`unlink()` method should "
 "be called to ensure proper cleanup."
 msgstr ""
+"Puisque qu'il permet de partager des données entre processus, un bloc de "
+"mémoire partagée peut survivre au processus qui l'a créé. Lorsqu'un "
+"processus n'a plus besoin d'un bloc — qui peut toujours être en cours "
+"d'utilisation par un autre — il doit appeler la méthode :meth:`close()`. "
+"Quand tous les processus ont fini d'utiliser ce bloc, il faut appeler la "
+"méthode :meth:`unlink()` pour le libérer."
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:54
 msgid ""
@@ -75,12 +107,17 @@ msgid ""
 "string.  When creating a new shared memory block, if ``None`` (the default) "
 "is supplied for the name, a novel name will be generated."
 msgstr ""
+"*name* est le nom (une chaîne de caractères) unique de la mémoire partagée à "
+"allouer. Lors de la création d'un nouveau bloc mémoire, si ``None`` (valeur "
+"par défaut) est passé comme nom, un nouveau nom est généré."
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:58
 msgid ""
 "*create* controls whether a new shared memory block is created (``True``) or "
 "an existing shared memory block is attached (``False``)."
 msgstr ""
+"*create* indique si un nouveau bloc doit être alloué (``True``) ou si on "
+"enregistre un bloc déjà existant (``False``)."
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:61
 msgid ""
@@ -90,6 +127,11 @@ msgid ""
 "memory block may be larger or equal to the size requested.  When attaching "
 "to an existing shared memory block, the ``size`` parameter is ignored."
 msgstr ""
+"*size* définit le nombre d'octets à allouer. Comme certaines plates-formes "
+"choisissent d'allouer les blocs mémoire en multiples de la taille de la page "
+"mémoire de la plate-forme, la taille réellement allouée peut être supérieure "
+"à la taille demandée. Lors de l'enregistrement d'un bloc déjà existant, le "
+"paramètre ``size`` est ignoré."
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:69
 msgid ""
@@ -98,6 +140,10 @@ msgid ""
 "instance is no longer needed.  Note that calling ``close()`` does not cause "
 "the shared memory block itself to be destroyed."
 msgstr ""
+"Empêche les accès ultérieurs à la mémoire partagée depuis cette instance ; "
+"toutes les instances doivent appeler ``close()`` pour s'assurer que les "
+"ressources sont bien libérées. Notez qu'appeler ``close()`` ne libère pas la "
+"mémoire elle-même."
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:77
 msgid ""
@@ -111,24 +157,35 @@ msgid ""
 "relinquishing its hold on a shared memory block may call ``unlink()`` and :"
 "meth:`close()` in either order."
 msgstr ""
+"Initie la libération de la mémoire partagée sous-jacente. Pour être sûr que "
+"les ressources sont libérées correctement, ``unlink()`` doit être appelée "
+"une (et une seule) fois par tous les processus qui ont utilisé le bloc "
+"partagé. Après avoir initié la destruction d'un bloc mémoire, le bloc peut "
+"ne pas être détruit immédiatement ; ce comportement dépend de la plate-"
+"forme. Accéder aux données d'un bloc de mémoire partagée après l'appel à "
+"``unlink()`` peut provoquer une erreur mémoire. Notez que le dernier "
+"processus à libérer le bloc mémoire de mémoire partagée peut appeler "
+"``unlink()`` et :meth:`close()` dans n'importe quel ordre."
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:90
 msgid "A memoryview of contents of the shared memory block."
-msgstr ""
+msgstr "Une *memoryview* du contenu du bloc de mémoire partagée."
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:94
 msgid "Read-only access to the unique name of the shared memory block."
-msgstr ""
+msgstr "Nom unique du bloc de mémoire partagée (lecture seule)."
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:98
 msgid "Read-only access to size in bytes of the shared memory block."
-msgstr ""
+msgstr "Taille en octets du bloc de mémoire partagée (lecture seule)."
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:101
 msgid ""
 "The following example demonstrates low-level use of :class:`SharedMemory` "
 "instances::"
 msgstr ""
+"L'exemple qui suit montre un exemple d'utilisation bas niveau d'instances "
+"de :class:`SharedMemory` :"
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:127
 msgid ""
@@ -136,12 +193,17 @@ msgid ""
 "`SharedMemory` class with `NumPy arrays <https://www.numpy.org/>`_, "
 "accessing the same ``numpy.ndarray`` from two distinct Python shells:"
 msgstr ""
+"Le code qui suit est un exemple d'utilisation réel de la classe :class:"
+"`SharedMemory` avec des `tableaux NumPy <https://www.numpy.org/>`_ qui "
+"accèdent au même ``numpy.ndarray`` depuis deux invites Python différentes :"
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:181
 msgid ""
 "A subclass of :class:`~multiprocessing.managers.BaseManager` which can be "
 "used for the management of shared memory blocks across processes."
 msgstr ""
+"Une sous-classe de :class:`~multiprocessing.managers.BaseManager` pour gérer "
+"des blocs de mémoire partagée entre processus."
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:184
 msgid ""
@@ -156,6 +218,16 @@ msgid ""
 "instances through a ``SharedMemoryManager``, we avoid the need to manually "
 "track and trigger the freeing of shared memory resources."
 msgstr ""
+"Un appel à :meth:`~multiprocessing.managers.BaseManager.start` depuis une "
+"instance :class:`SharedMemoryManager` lance un nouveau processus dont le "
+"seul but est de gérer le cycle de vie des blocs mémoires qu'il a créés. La "
+"méthode :meth:`~multiprocessing.managers.BaseManager.shutdown()` de "
+"l'instance déclenche la libération de tous les blocs mémoires gérés par ce "
+"processus. Elle appelle :meth:`SharedMemory.unlink()` sur tous les objets :"
+"class:`SharedMemory` gérés par ce processus et l'arrête ensuite. Créer des "
+"instances de ``SharedMemory`` par l'intermédiaire d'un "
+"``SharedMemoryManager`` évite d'avoir à gérer et à libérer manuellement les "
+"ressources mémoire partagées."
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:196
 msgid ""
@@ -163,6 +235,9 @@ msgid ""
 "instances and for creating a list-like object (:class:`ShareableList`) "
 "backed by shared memory."
 msgstr ""
+"Cette classe fournit des méthodes pour créer et renvoyer des instances de :"
+"class:`SharedMemory` et pour créer des objets compatibles liste (:class:"
+"`ShareableList`) basés sur la mémoire partagée."
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:200
 msgid ""
@@ -171,24 +246,34 @@ msgid ""
 "may be used to connect to an existing ``SharedMemoryManager`` service from "
 "other processes."
 msgstr ""
+"Référez-vous à :class:`multiprocessing.managers.BaseManager` pour la "
+"description des arguments optionnels hérités *address* et *authkey*, et "
+"comment ceux-ci doivent être utilisés pour enregistrer un service de "
+"``SharedMemoryManager`` depuis un autre processus."
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:207
 msgid ""
 "Create and return a new :class:`SharedMemory` object with the specified "
 "``size`` in bytes."
 msgstr ""
+"Crée et renvoie un nouvel objet :class:`SharedMemory` de taille ``size`` "
+"octets."
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:212
 msgid ""
 "Create and return a new :class:`ShareableList` object, initialized by the "
 "values from the input ``sequence``."
 msgstr ""
+"Crée et renvoie un nouvel objet :class:`ShareableList`, initialisé à partir "
+"des valeurs de la ``sequence`` en entrée."
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:216
 msgid ""
 "The following example demonstrates the basic mechanisms of a :class:"
 "`SharedMemoryManager`:"
 msgstr ""
+"L'exemple qui suit illustre les mécanismes de base de :class:"
+"`SharedMemoryManager` :"
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:234
 msgid ""
@@ -197,6 +282,10 @@ msgid ""
 "to ensure that all shared memory blocks are released after they are no "
 "longer needed:"
 msgstr ""
+"L'exemple suivant montre comment utiliser un objet :class:"
+"`SharedMemoryManager` avec l'instruction :keyword:`with` pour être sûr que "
+"tous les blocs mémoire sont libérés quand ils ne sont plus nécessaires. "
+"C'est souvent plus pratique que l'exemple précédent :"
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:253
 msgid ""
@@ -204,6 +293,10 @@ msgid ""
 "the shared memory blocks created using that manager are all released when "
 "the :keyword:`with` statement's code block finishes execution."
 msgstr ""
+"Lors de l'utilisation d'un :class:`SharedMemoryManager` dans une "
+"instruction :keyword:`with`, les blocs de mémoire partagée créés par ce "
+"gestionnaire sont tous libérés quand les instructions à l'intérieur du bloc :"
+"keyword:`with` ont été exécutées."
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:260
 msgid ""
@@ -216,6 +309,14 @@ msgid ""
 "support the dynamic creation of new :class:`ShareableList` instances via "
 "slicing."
 msgstr ""
+"Construit un objet muable compatible avec le type liste dont toutes les "
+"valeurs sont stockées dans un bloc de mémoire partagée. Ceci réduit le type "
+"les valeurs pouvant être stockées aux types natifs ``int``, ``float``, "
+"``bool``, ``str`` (de moins de 10 Mo chacune), ``bytes`` (de moins de 10 Mo "
+"chacun) et ``None``. Une autre différence majeure avec une ``list`` native "
+"réside dans le fait qu'il est impossible de changer la taille (c.-à-d. pas "
+"d'ajout en fin de liste, ni d'insertion etc.) et qu'il n'est pas possible de "
+"créer de nouvelles instances de :class:`ShareableList` par découpage."
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:269
 msgid ""
@@ -223,6 +324,9 @@ msgid ""
 "to ``None`` to instead attach to an already existing ``ShareableList`` by "
 "its unique shared memory name."
 msgstr ""
+"*sequence* sert à créer une nouvelle ``ShareableList`` avec des valeurs. "
+"Mettez-le à ``None`` pour enregistrer une ``ShareableList`` déjà existante, "
+"en renseignant son nom unique."
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:273
 msgid ""
@@ -231,32 +335,43 @@ msgid ""
 "``ShareableList``, specify its shared memory block's unique name while "
 "leaving ``sequence`` set to ``None``."
 msgstr ""
+"*name* est le nom unique de la mémoire partagée demandée, tel que décrit "
+"dans la définition de :class:`SharedMemory`. Pour enregistrer une "
+"``ShareableList`` déjà existante, renseignez le nom unique du bloc de "
+"mémoire partagée et laissez ``sequence`` à ``None``."
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:280
 msgid "Returns the number of occurrences of ``value``."
-msgstr ""
+msgstr "Renvoie le nombre d’occurrences de ``value``."
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:284
 msgid ""
 "Returns first index position of ``value``.  Raises :exc:`ValueError` if "
 "``value`` is not present."
 msgstr ""
+"Renvoie l'indice de la première occurrence de ``value``. Lève une :exc:"
+"`ValueError` si ``value`` n'est pas présent."
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:289
 msgid ""
 "Read-only attribute containing the :mod:`struct` packing format used by all "
 "currently stored values."
 msgstr ""
+"Attribut en lecture seule contenant le format d’agrégation :mod:`struct` "
+"utilisé par les valeurs déjà stockées."
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:294
 msgid "The :class:`SharedMemory` instance where the values are stored."
 msgstr ""
+"Instance de :class:`SharedMemory` dans laquelle les valeurs sont stockées."
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:297
 msgid ""
 "The following example demonstrates basic use of a :class:`ShareableList` "
 "instance:"
 msgstr ""
+"L'exemple qui suit illustre un cas d'usage de base d'une instance de :class:"
+"`ShareableList` :"
 
 #: ../Doc/library/multiprocessing.shared_memory.rst:330
 msgid ""
@@ -264,3 +379,6 @@ msgid ""
 "same :class:`ShareableList` by supplying the name of the shared memory block "
 "behind it:"
 msgstr ""
+"L'exemple ci-dessous montre comment un, deux ou un grand nombre de processus "
+"peuvent accéder à une :class:`ShareableList` commune à partir du nom du bloc "
+"mémoire partagé sous-jacent :"

--- a/library/resource.po
+++ b/library/resource.po
@@ -334,7 +334,7 @@ msgstr "Index"
 
 #: ../Doc/library/resource.rst:300
 msgid "Field"
-msgstr ""
+msgstr "Champ"
 
 #: ../Doc/library/resource.rst:300
 msgid "Resource"

--- a/library/sunau.po
+++ b/library/sunau.po
@@ -37,7 +37,7 @@ msgstr ""
 
 #: ../Doc/library/sunau.rst:21
 msgid "Field"
-msgstr ""
+msgstr "Champ"
 
 #: ../Doc/library/sunau.rst:21
 msgid "Contents"

--- a/library/tarfile.po
+++ b/library/tarfile.po
@@ -246,7 +246,7 @@ msgstr ""
 
 #: ../Doc/library/tarfile.rst:117
 msgid "Mode"
-msgstr ""
+msgstr "Mode"
 
 #: ../Doc/library/tarfile.rst:117
 msgid "Action"

--- a/library/tkinter.ttk.po
+++ b/library/tkinter.ttk.po
@@ -1688,7 +1688,7 @@ msgstr ""
 
 #: ../Doc/library/tkinter.ttk.rst:1089
 msgid "tree"
-msgstr ""
+msgstr "*tree* (arbre)"
 
 #: ../Doc/library/tkinter.ttk.rst:1089
 msgid "The tree area."

--- a/library/zoneinfo.po
+++ b/library/zoneinfo.po
@@ -387,7 +387,7 @@ msgstr ""
 
 #: /home/mdk/clones/python/cpython/Doc/library/zoneinfo.rst:338
 msgid "Functions"
-msgstr ""
+msgstr "Fonctions"
 
 #: /home/mdk/clones/python/cpython/Doc/library/zoneinfo.rst:342
 msgid ""

--- a/whatsnew/2.7.po
+++ b/whatsnew/2.7.po
@@ -1957,7 +1957,7 @@ msgstr ""
 
 #: ../Doc/whatsnew/2.7.rst:1752
 msgid "Here are some examples::"
-msgstr ""
+msgstr "Voici quelques exemples :"
 
 #: ../Doc/whatsnew/2.7.rst:1763
 msgid ""

--- a/whatsnew/3.2.po
+++ b/whatsnew/3.2.po
@@ -2733,7 +2733,7 @@ msgstr ""
 
 #: ../Doc/whatsnew/3.2.rst:2432
 msgid "Codecs"
-msgstr ""
+msgstr "Codecs"
 
 #: ../Doc/whatsnew/3.2.rst:2434
 msgid "Support was added for *cp720* Arabic DOS encoding (:issue:`1616979`)."

--- a/whatsnew/3.3.po
+++ b/whatsnew/3.3.po
@@ -215,7 +215,7 @@ msgstr ""
 
 #: ../Doc/whatsnew/3.3.rst:161 ../Doc/whatsnew/3.3.rst:1122
 msgid "Features"
-msgstr ""
+msgstr "Caractéristiques"
 
 #: ../Doc/whatsnew/3.3.rst:163
 msgid ""

--- a/whatsnew/3.7.po
+++ b/whatsnew/3.7.po
@@ -21,7 +21,7 @@ msgstr "Nouveautés de Python 3.0"
 
 #: ../Doc/whatsnew/3.7.rst:0
 msgid "Editor"
-msgstr ""
+msgstr "Rédacteur"
 
 #: ../Doc/whatsnew/3.7.rst:5
 msgid "Elvis Pranskevichus <elvis@magic.io>"

--- a/whatsnew/3.9.po
+++ b/whatsnew/3.9.po
@@ -19,7 +19,7 @@ msgstr ""
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:0
 msgid "Release"
-msgstr ""
+msgstr "Version"
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:5
 msgid "|release|"
@@ -31,7 +31,7 @@ msgstr ""
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:6
 msgid "|today|"
-msgstr ""
+msgstr "|today|"
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:48
 msgid "This article explains the new features in Python 3.9, compared to 3.8."
@@ -101,7 +101,7 @@ msgstr ""
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:99
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:1014
 msgid "New Features"
-msgstr ""
+msgstr "Nouvelles fonctionnalités"
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:102
 msgid "Dictionary Merge & Update Operators"
@@ -144,7 +144,7 @@ msgstr ""
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:127
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:946
 msgid "Example:"
-msgstr ""
+msgstr "Exemple :"
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:135
 msgid ""
@@ -265,7 +265,7 @@ msgstr ""
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:215
 msgid "Example::"
-msgstr ""
+msgstr "Exemple ::"
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:235
 msgid ""
@@ -289,7 +289,7 @@ msgstr ""
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:252
 msgid "ast"
-msgstr ""
+msgstr "ast"
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:254
 msgid ""
@@ -314,7 +314,7 @@ msgstr ""
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:267
 msgid "asyncio"
-msgstr ""
+msgstr "asyncio"
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:269
 msgid ""
@@ -352,7 +352,7 @@ msgstr ""
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:292
 msgid "compileall"
-msgstr ""
+msgstr "compileall"
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:294
 msgid ""
@@ -372,7 +372,7 @@ msgstr ""
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:302
 msgid "concurrent.futures"
-msgstr ""
+msgstr "concurrent.futures"
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:304
 msgid ""
@@ -400,7 +400,7 @@ msgstr ""
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:321
 msgid "curses"
-msgstr ""
+msgstr "curses"
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:323
 msgid ""
@@ -411,7 +411,7 @@ msgstr ""
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:328
 msgid "datetime"
-msgstr ""
+msgstr "datetime"
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:329
 msgid ""
@@ -423,7 +423,7 @@ msgstr ""
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:335
 msgid "distutils"
-msgstr ""
+msgstr "distutils"
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:337
 msgid ""
@@ -534,7 +534,7 @@ msgstr ""
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:407
 msgid "importlib"
-msgstr ""
+msgstr "importlib"
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:409
 msgid ""
@@ -605,7 +605,7 @@ msgstr ""
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:449
 msgid "multiprocessing"
-msgstr ""
+msgstr "multiprocessing"
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:451
 msgid ""
@@ -662,7 +662,7 @@ msgstr ""
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:485
 msgid "pathlib"
-msgstr ""
+msgstr "pathlib"
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:487
 msgid ""
@@ -761,7 +761,7 @@ msgstr ""
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:544
 msgid "time"
-msgstr ""
+msgstr "time"
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:546
 msgid ""
@@ -773,7 +773,7 @@ msgstr ""
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:552
 msgid "sys"
-msgstr ""
+msgstr "sys"
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:554
 msgid ""
@@ -806,7 +806,7 @@ msgstr ""
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:574
 msgid "unicodedata"
-msgstr ""
+msgstr "unicodedata"
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:576
 msgid ""
@@ -815,7 +815,7 @@ msgstr ""
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:579
 msgid "venv"
-msgstr ""
+msgstr "venv"
 
 #: /home/mdk/clones/python/cpython/Doc/whatsnew/3.9.rst:581
 msgid ""


### PR DESCRIPTION
En utilisant https://github.com/python/python-docs-fr/pull/1339

Les paragraphes viennent donc de la 3.8, je n'ai rien écrit moi même, ce n'est pas *vraiment* la peine de relire (s'il y a une erreur, on peut la corriger dans une autre PR).
