### PR TITLE
library/os: quelques fuzzies simples + une reformulation

### DIFF
--- a/library/os.po
+++ b/library/os.po
@@ -6,14 +6,14 @@ msgstr ""
 "Project-Id-Version: Python 3\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-05-23 11:38+0200\n"
-"PO-Revision-Date: 2020-05-27 15:06+0200\n"
+"PO-Revision-Date: 2020-06-08 12:50+0200\n"
 "Last-Translator: Mathieu Dupuy <deronnax@gmail.com>\n"
 "Language-Team: FRENCH <traductions@lists.afpy.org>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.3\n"
+"X-Generator: Poedit 2.3.1\n"
 
 #: ../Doc/library/os.rst:2
 msgid ":mod:`os` --- Miscellaneous operating system interfaces"
@@ -2255,13 +2255,12 @@ msgstr ""
 "un fichier ouvert."
 
 #: ../Doc/library/os.rst:1612
-#, fuzzy
 msgid ""
 "This function can raise :exc:`OSError` and subclasses such as :exc:"
 "`FileNotFoundError`, :exc:`PermissionError`, and :exc:`NotADirectoryError`."
 msgstr ""
-"Cette méthode peut lever une :exc:`OSError` tout comme une :exc:"
-"`PermissionError`, mais :exc:`FileNotFoundError` est attrapé et pas levé."
+"Cette fonction peut lever :exc:`OSError` et des sous-classes telles que :exc:"
+"`FileNotFoundError`, :exc:`PermissionError`, et :exc:`NotADirectoryError`."
 
 #: ../Doc/library/os.rst:1616 ../Doc/library/os.rst:1743
 msgid ""
@@ -2960,7 +2959,8 @@ msgstr "Accepte un :term:`path-like object` sur Unix."
 
 #: ../Doc/library/os.rst:2095
 msgid "Accepts a :term:`path-like object` and a bytes object on Windows."
-msgstr "Accepte un :term:`path-like object` et un objet octets sous Windows."
+msgstr ""
+"Accepte un :term:`path-like object` et une chaine d’octets sous Windows."
 
 #: ../Doc/library/os.rst:2098
 msgid ""
@@ -2970,14 +2970,13 @@ msgid ""
 msgstr ""
 
 #: ../Doc/library/os.rst:2105
-#, fuzzy
 msgid ""
 "Remove (delete) the file *path*.  If *path* is a directory, an :exc:"
 "`IsADirectoryError` is raised.  Use :func:`rmdir` to remove directories."
 msgstr ""
-"Supprime (retire) le fichier représenté par *path*. Si *path* est un "
-"répertoire, une :exc:`OSError` est levée. Utilisez la fonction :func:`rmdir` "
-"pour supprimer un répertoire."
+"Supprime (efface) le fichier *path*. Si *path* est un répertoire, une :exc:"
+"`IsADirectoryError` est levée.  Utilisez :func:`rmdir` pour supprimer les "
+"répertoires."
 
 #: ../Doc/library/os.rst:2108 ../Doc/library/os.rst:2219
 #: ../Doc/library/os.rst:2853
@@ -3137,17 +3136,16 @@ msgstr ""
 "atomique (nécessité POSIX)."
 
 #: ../Doc/library/os.rst:2214
-#, fuzzy
 msgid ""
 "Remove (delete) the directory *path*.  If the directory does not exist or is "
 "not empty, an :exc:`FileNotFoundError` or an :exc:`OSError` is raised "
 "respectively.  In order to remove whole directory trees, :func:`shutil."
 "rmtree` can be used."
 msgstr ""
-"Supprime (retire) le répertoire *path*. Ne fonctionne que lorsque le "
-"répertoire est vide, sinon une :exc:`OSError` est levée. Afin de supprimer "
-"toute la hiérarchie de dossier, la fonction :func:`shutil.rmtree` peut être "
-"utilisée."
+"Supprime (efface) le répertoire *path*. Si le répertoire n'existe pas ou "
+"n'est pas vide, une :exc:`FileNotFoundError` ou une :exc:`OSError` est "
+"levée, selon le cas. Pour supprimer des arborescences de répertoires "
+"entières, utiliser :func:`shutil.rmtree`."
 
 #: ../Doc/library/os.rst:2223
 msgid ""
@@ -4342,13 +4340,12 @@ msgid ""
 msgstr ""
 
 #: ../Doc/library/os.rst:2962
-#, fuzzy
 msgid ""
 "Added support for specifying *path* as an open file descriptor, and the "
 "*dir_fd*, *follow_symlinks*, and *ns* parameters."
 msgstr ""
-"Prise en charge de la spécification d'un descripteur de fichier pour *path* "
-"et les paramètres *dir_fd*, *follow_symlinks*, et *ns* ajoutés."
+"Ajoute la prise en charge d'un descripteur de fichier pour *path* et des "
+"paramètres *dir_fd*, *follow_symlinks*, et *ns* ajoutés."
 
 #: ../Doc/library/os.rst:2976
 msgid ""
@@ -4568,11 +4565,12 @@ msgid ""
 msgstr ""
 
 #: ../Doc/library/os.rst:3140
-#, fuzzy
 msgid ""
 ":ref:`Availability <availability>`: Linux 3.17 or newer with glibc 2.27 or "
 "newer."
-msgstr ":ref:`Disponibilité <availability>` : Linux 3.17 et ultérieures."
+msgstr ""
+":ref:`Disponibilité <availability>` : Linux 3.17 ou plus récent avec glibc "
+"2.27 ou plus récent."
 
 #: ../Doc/library/os.rst:3162
 msgid "These flags can be passed to :func:`memfd_create`."

--- a/library/os.po
+++ b/library/os.po
@@ -3145,7 +3145,7 @@ msgstr ""
 "Supprime (efface) le répertoire *path*. Si le répertoire n'existe pas ou "
 "n'est pas vide, une :exc:`FileNotFoundError` ou une :exc:`OSError` est "
 "levée, selon le cas. Pour supprimer des arborescences de répertoires "
-"entières, utiliser :func:`shutil.rmtree`."
+"entières, utilisez :func:`shutil.rmtree`."
 
 #: ../Doc/library/os.rst:2223
 msgid ""
@@ -4345,7 +4345,7 @@ msgid ""
 "*dir_fd*, *follow_symlinks*, and *ns* parameters."
 msgstr ""
 "Ajoute la prise en charge d'un descripteur de fichier pour *path* et des "
-"paramètres *dir_fd*, *follow_symlinks*, et *ns* ajoutés."
+"paramètres *dir_fd*, *follow_symlinks* et *ns*."
 
 #: ../Doc/library/os.rst:2976
 msgid ""
@@ -4570,7 +4570,7 @@ msgid ""
 "newer."
 msgstr ""
 ":ref:`Disponibilité <availability>` : Linux 3.17 ou plus récent avec glibc "
-"2.27 ou plus récent."
+"2.27 ou plus récente."
 
 #: ../Doc/library/os.rst:3162
 msgid "These flags can be passed to :func:`memfd_create`."

--- a/library/os.po
+++ b/library/os.po
@@ -2260,7 +2260,7 @@ msgid ""
 "`FileNotFoundError`, :exc:`PermissionError`, and :exc:`NotADirectoryError`."
 msgstr ""
 "Cette fonction peut lever :exc:`OSError` et des sous-classes telles que :exc:"
-"`FileNotFoundError`, :exc:`PermissionError`, et :exc:`NotADirectoryError`."
+"`FileNotFoundError`, :exc:`PermissionError` et :exc:`NotADirectoryError`."
 
 #: ../Doc/library/os.rst:1616 ../Doc/library/os.rst:1743
 msgid ""


### PR DESCRIPTION
Quelque fuzzies très simples plus une reformulation que je trouve importante :
On a pas mal traduit "byte objects" par "objets octets", ce qui pour moi n'a pas de sens tel quel en français (c'est quoi, une socket qui accepte des octets ? une pipe, une memory view ? Au fait, ça en accepte ou ça en donne ? Les deux, peut être ?). On sait qu'en fait c'est une séquence d'octets, donc hop reformulation.
Ça pourrait peut être faire une guideline.