### PR TITLE
rapide relecture library/json.po

### DIFF
--- a/library/json.po
+++ b/library/json.po
@@ -6,14 +6,14 @@ msgstr ""
 "Project-Id-Version: Python 3\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-07-20 10:51+0200\n"
-"PO-Revision-Date: 2020-05-16 22:52+0200\n"
+"PO-Revision-Date: 2020-08-10 16:10+0200\n"
 "Last-Translator: Antoine Wecxsteen\n"
 "Language-Team: FRENCH <traductions@lists.afpy.org>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.2.4\n"
+"X-Generator: Poedit 2.4\n"
 
 #: library/json.rst:2
 msgid ":mod:`json` --- JSON encoder and decoder"
@@ -423,11 +423,8 @@ msgstr ""
 "cette :ref:`table de conversion <json-to-py-table>`."
 
 #: library/json.rst:286
-#, fuzzy
 msgid "The other arguments have the same meaning as in :func:`load`."
-msgstr ""
-"Les autres arguments ont la même signification que pour :func:`load`, à "
-"l'exception d'*encoding* qui est ignoré et obsolète depuis Python 3.1."
+msgstr "Les autres arguments ont la même signification que dans :func:`load`."
 
 #: library/json.rst:291
 msgid ""
@@ -439,7 +436,7 @@ msgstr ""
 
 #: library/json.rst:295
 msgid "The keyword argument *encoding* has been removed."
-msgstr ""
+msgstr "L’argument nommé *encoding* a été supprimé."
 
 #: library/json.rst:300
 msgid "Encoders and Decoders"
@@ -602,7 +599,7 @@ msgid ""
 "*s* where the document ended."
 msgstr ""
 "Décode en document JSON depuis *s* (une instance :class:`str` débutant par "
-"un document JSON) et renvoie un *tuple* de 2 éléments contenant la "
+"un document JSON) et renvoie un n-uplet de 2 éléments contenant la "
 "représentation Python de l'objet et l'index dans *s* où le document se "
 "terminait."
 
@@ -1068,6 +1065,8 @@ msgid ""
 "Disable escaping of non-ascii characters, see :func:`json.dumps` for more "
 "information."
 msgstr ""
+"Désactivez l’échappement des caractères non ASCII, voir :func:`json.dumps` "
+"pour plus d'informations."
 
 #: library/json.rst:742
 msgid "Parse every input line as separate JSON object."
@@ -1076,6 +1075,8 @@ msgstr "Transforme chaque ligne d'entrée en un objet JSON individuel."
 #: library/json.rst:748
 msgid "Mutually exclusive options for whitespace control"
 msgstr ""
+"Options mutuellement exclusives pour le contrôle des caractères "
+"d’espacements (caractères « blancs »)"
 
 #: library/json.rst:754
 msgid "Show the help message."

--- a/library/json.po
+++ b/library/json.po
@@ -436,7 +436,7 @@ msgstr ""
 
 #: library/json.rst:295
 msgid "The keyword argument *encoding* has been removed."
-msgstr "L’argument nommé *encoding* a été supprimé."
+msgstr "l’argument nommé *encoding* a été supprimé."
 
 #: library/json.rst:300
 msgid "Encoders and Decoders"

--- a/library/json.po
+++ b/library/json.po
@@ -1076,7 +1076,7 @@ msgstr "Transforme chaque ligne d'entrée en un objet JSON individuel."
 msgid "Mutually exclusive options for whitespace control"
 msgstr ""
 "Options mutuellement exclusives pour le contrôle des caractères "
-"d’espacements (caractères « blancs »)"
+"d’espacements (caractères « blancs »)."
 
 #: library/json.rst:754
 msgid "Show the help message."

--- a/library/json.po
+++ b/library/json.po
@@ -436,7 +436,7 @@ msgstr ""
 
 #: library/json.rst:295
 msgid "The keyword argument *encoding* has been removed."
-msgstr "l’argument nommé *encoding* a été supprimé."
+msgstr "suppression de l’argument nommé *encoding*."
 
 #: library/json.rst:300
 msgid "Encoders and Decoders"
@@ -1065,7 +1065,7 @@ msgid ""
 "Disable escaping of non-ascii characters, see :func:`json.dumps` for more "
 "information."
 msgstr ""
-"Désactivez l’échappement des caractères non ASCII, voir :func:`json.dumps` "
+"Désactive l’échappement des caractères non ASCII, voir :func:`json.dumps` "
 "pour plus d'informations."
 
 #: library/json.rst:742


### PR DESCRIPTION
on a pas de traduction pour *whitespace*, que le texte original adore utiliser.