### PR TITLE
translated 'math.nextafter(x,y)'

### DIFF
--- a/library/math.po
+++ b/library/math.po
@@ -372,37 +372,41 @@ msgstr ""
 "le signe de *x* et sont flottants."
 
 #: library/math.rst:234
-#, fuzzy
 msgid "Return the next floating-point value after *x* towards *y*."
-msgstr "Renvoie la tangente de *x* radians."
+msgstr ""
+"Renvoie la valeur flottante consécutive à *x*, dans la direction de *y*."
 
 #: library/math.rst:236
 msgid "If *x* is equal to *y*, return *y*."
-msgstr ""
+msgstr "Si *x* est égal à *y*, renvoie *y*."
 
 #: library/math.rst:238
 msgid "Examples:"
-msgstr ""
+msgstr "Exemples :"
 
 #: library/math.rst:240
 msgid "``math.nextafter(x, math.inf)`` goes up: towards positive infinity."
 msgstr ""
+"``math.nextafter(x, math.inf)`` augmente de valeur : vers l'infini positif."
 
 #: library/math.rst:241
 msgid "``math.nextafter(x, -math.inf)`` goes down: towards minus infinity."
 msgstr ""
+"``math.nextafter(x, -math.inf)`` baisse de valeur : vers l'infini négatif."
 
 #: library/math.rst:242
 msgid "``math.nextafter(x, 0.0)`` goes towards zero."
-msgstr ""
+msgstr "``math.nextafter(x, 0.0)`` augmente ou baisse de valeur, vers zéro."
 
 #: library/math.rst:243
 msgid "``math.nextafter(x, math.copysign(math.inf, x))`` goes away from zero."
 msgstr ""
+"``math.nextafter(x, math.copysign(math.inf, x))`` augmente ou baisse de "
+"valeur, en s'éloignant de zéro."
 
 #: library/math.rst:245
 msgid "See also :func:`math.ulp`."
-msgstr ""
+msgstr "Voir aussi : :func:`math.ulp`."
 
 #: library/math.rst:251
 msgid ""


### PR DESCRIPTION
Bonjour,

Afin de me préparer à un atelier de traduction de la doc python-docs-fr, je voulais tester le processus. J'ai fait une très courte traduction de la description d'une seule fonction. 

J'ai suivi les instructions au meilleur de mes connaissances.

Dites-moi ce qu'il en est :smiley:

Closes #1379 .