### PR TITLE
retire marqueur fuzzy d'une chaine corrigée upstream

### DIFF
--- a/howto/sockets.po
+++ b/howto/sockets.po
@@ -6,14 +6,14 @@ msgstr ""
 "Project-Id-Version: Python 3\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-08-24 09:01+0200\n"
-"PO-Revision-Date: 2020-05-08 15:38+0200\n"
+"PO-Revision-Date: 2020-09-30 17:07+0200\n"
 "Last-Translator: Mathieu Dupuy <deronnax@gmail.com>\n"
 "Language-Team: FRENCH <traductions@lists.afpy.org>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.3\n"
+"X-Generator: Poedit 2.4.1\n"
 
 #: howto/sockets.rst:5
 msgid "Socket Programming HOWTO"
@@ -617,7 +617,6 @@ msgstr ""
 "faites bien, c’est presque dans la poche."
 
 #: howto/sockets.rst:320
-#, fuzzy
 msgid ""
 "In Python, you use ``socket.setblocking(False)`` to make it non-blocking. In "
 "C, it's more complex, (for one thing, you'll need to choose between the BSD "


### PR DESCRIPTION
Posix a été corrigé en POSIX upstream (par moi), la correction est déjà présente downstream.
