### PR TITLE
library/stdtypes: accorde le participe passé de "entré"

### DIFF
--- a/library/stdtypes.po
+++ b/library/stdtypes.po
@@ -4032,7 +4032,7 @@ msgid ""
 msgstr ""
 "Seuls les caractères ASCII sont autorisés dans les littéraux de *bytes* "
 "(quel que soit l'encodage du code source déclaré). Toutes les valeurs au "
-"delà de 127 doivent être entrés dans littéraux de *bytes* en utilisant une "
+"delà de 127 doivent être entrées dans littéraux de *bytes* en utilisant une "
 "séquence d'échappement appropriée."
 
 #: library/stdtypes.rst:2419


### PR DESCRIPTION
mais toute la page mériterait une relecture, c'est traduit comme en 2012