### PR TITLE
Set a shorter timeout on this build (6h by default).

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,7 @@ jobs:
   sphinx:
     name: 'Génération de la doc (sphinx)'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2


### PR DESCRIPTION
It should not take long, but we've seen it timeouting (probably for
another reason that really taking 6+ hours), so a shorter timeout may
be sane here.