### PR TITLE
Added locales folder to potodoignore, which could cause confusion

### DIFF
--- a/.potodoignore
+++ b/.potodoignore
@@ -1,1 +1,2 @@
 venv/
+locales/


### PR DESCRIPTION
This was causing confusion, mainly for me, as I thought the `glossary.po` displayed was the one on the root of the project, creating this issue:

https://github.com/AFPy/Potodo/issues/115