### PR TITLE
Makefile:  don't run `git checkout -` at the end of the build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,6 @@ all: ensure_prerequisites
 	  -D latex_elements.inputenc=       \
 	  -D latex_elements.fontenc='       \
 	  $(MODE)
-	git -C $(CPYTHON_PATH) checkout -
 	@echo "Build success, open file://$(abspath $(CPYTHON_PATH))/Doc/build/html/index.html or run 'make serve' to see them."
 
 


### PR DESCRIPTION
Running `git checkout CPYTHON_CURRENT_COMMIT` and then
`git checkout -c` can render the spinx build slower
because many sources may seem out of date.

It's better to check if we are at the correct revision and
not run *any* git operations if there's nothing to be done