### PR TITLE
Ajout d'une section sur la gestion des suggestions

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -237,7 +237,7 @@ Il peut arriver que vous ayez besoin de reprendre votre PR sur votre
 ordinateur après avoir fait des modifications en ligne sur GitHub,
 par exemple lorsque GitHub vous offre la possibilité de faire un commit
 automatique contenant les suggestions proposées pendant la revue.
- Cela fonctionne bien, mais le résultat n'est pas toujours accepté par
+Cela fonctionne bien, mais le résultat n'est pas toujours accepté par
 ``powrap``. Si cela arrive, vous pouvez récupérer le commit fait par
 GitHub puis relancer ``powrap``:
 
@@ -788,4 +788,3 @@ ce qui suit après vous être assuré que ``~/.local/bin/`` se trouve dans votre
 
 Pas d'inquiétude, cela ne change la façon dont Git affiche les changements que sur
 les fichiers de la traduction, sans incidence sur les autres.
-

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -233,6 +233,21 @@ Mettez dans le commentaire de la *pull request* le texte suivant :
 « Closes #XXXX » où XXXX est le numéro du ticket GitHub créé pour réserver le fichier traduit.
 Cela permet à Github de lier la *pull request* au ticket de réservation.
 
+Il peut arriver que vous ayez besoin de reprendre votre PR sur votre
+ordinateur après avoir fait des modifications en ligne sur GitHub,
+par exemple lorsque GitHub vous offre la possibilité de faire un commit
+automatique contenant les suggestions proposées pendant la revue.
+ Cela fonctionne bien, mais le résultat n'est pas toujours accepté par
+``powrap``. Si cela arrive, vous pouvez récupérer le commit fait par
+GitHub puis relancer ``powrap``:
+
+.. code-block:: bash
+
+    git pull
+    powrap <fichier.po>
+    git add <fichier.po>
+    git commit -m "Formatage après commit automatique"
+    git push
 
 Sur une autre forge
 +++++++++++++++++++

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -239,7 +239,7 @@ par exemple lorsque GitHub vous offre la possibilité de faire un commit
 automatique contenant les suggestions proposées pendant la revue.
 Cela fonctionne bien, mais le résultat n'est pas toujours accepté par
 ``powrap``. Si cela arrive, vous pouvez récupérer le commit fait par
-GitHub puis relancer ``powrap``:
+GitHub puis relancer ``powrap`` :
 
 .. code-block:: bash
 


### PR DESCRIPTION
Un ajout dans CONTRIBUTING.rst que je trouve utile.

Peut-être qu'il faut rajouter une section pour expliquer comment appliquer toutes les suggestions en un seul commit
(l'astuce c'est de passer par la vue "Changed files" et de cliquer sur "Add suggestion to batch")

