### PR TITLE
Pas de -W explicite pour Sphinx

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,4 +91,4 @@ jobs:
           [ -d $HOME/cpython/Doc/venv/bin/ -a ! -e $HOME/cpython/Doc/venv/bin/python ] && rm -fr $HOME/cpython/Doc/venv
           make -C $HOME/cpython/Doc venv
       - name: sphinx-build
-        run: make -C $HOME/cpython/Doc SPHINXOPTS="-qW -j4 -D locale_dirs=$HOME/locales -D language=fr -D gettext_compact=0" autobuild-dev-html
+        run: make -C $HOME/cpython/Doc SPHINXOPTS="-q -j4 -D locale_dirs=$HOME/locales -D language=fr -D gettext_compact=0" autobuild-dev-html

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ all: ensure_prerequisites
 	mkdir -p locales/$(LANGUAGE)/LC_MESSAGES/
 	$(CP_CMD) -u --parents *.po */*.po locales/$(LANGUAGE)/LC_MESSAGES/
 	$(MAKE) -C $(CPYTHON_PATH)/Doc/     \
-	  SPHINXOPTS='-W -j$(JOBS)         \
+	  SPHINXOPTS='-j$(JOBS)         \
 	  -D locale_dirs=$(abspath locales) \
 	  -D language=$(LANGUAGE)           \
 	  -D gettext_compact=0           \


### PR DESCRIPTION
CPython ajoute déjà -W dans son Makefile. Depuis le commit
f98c1623ec90508937afc1b58556e38214d70892 ("Doc: -W flag for sphinx-build
can be disabled" par Julien Palard), c'est même configurable à l'aide de
la variable SPHINXERRORHANDLING. Avec le présent commit, cette variable
fonctionne aussi dans notre traduction, ce qui permet des recompilations
plus rapides pendant la traduction avec « make SPHINXERRORHANDLING= » ou
bien « make SPHINXERRORHANDLING="-W --keep-going" ». Ce serait bien
d'avoir --keep-going par défaut, mais je ne l'ajoute pas ici car il
serait sûrement encore mieux de le mettre dans CPython directement.