### PR TITLE
Fuzzies in tutorial/errors.po

### DIFF
--- a/tutorial/errors.po
+++ b/tutorial/errors.po
@@ -6,8 +6,8 @@ msgstr ""
 "Project-Id-Version: Python 3\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-09-23 16:16+0200\n"
-"PO-Revision-Date: 2021-09-04 02:20+0200\n"
-"Last-Translator: Jean Abou Samra <jean@abou-samra.fr>\n"
+"PO-Revision-Date: 2021-09-25 11:49+0200\n"
+"Last-Translator: Julien Palard <julien@palard.fr>\n"
 "Language-Team: FRENCH <traductions@lists.afpy.org>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -171,22 +171,20 @@ msgstr ""
 "l'exécution de l'instruction :keyword:`try` est terminée."
 
 #: tutorial/errors.rst:104
-#, fuzzy
 msgid ""
 "If an exception occurs during execution of the :keyword:`try` clause, the "
 "rest of the clause is skipped.  Then, if its type matches the exception "
 "named after the :keyword:`except` keyword, the *except clause* is executed, "
 "and then execution continues after the try/except block."
 msgstr ""
-"si une exception intervient pendant l'exécution de la clause ``try``, le "
-"reste de cette clause est sauté. Si le type d'exception levée correspond à "
-"un nom indiqué après le mot-clé :keyword:`except`, la clause ``except`` "
-"correspondante est exécutée, puis l'exécution continue après l'instruction :"
-"keyword:`try`."
+"si une exception intervient pendant l'exécution de la clause :keyword:`try`, "
+"le reste de cette clause est sauté. Si le type d'exception levée correspond "
+"à un nom indiqué après le mot-clé :keyword:`except`, la clause ``except`` "
+"correspondante est exécutée, puis l'exécution continue après le bloc ``try``/"
+"``except``."
 
 # dernier élément de l'énumération
 #: tutorial/errors.rst:109
-#, fuzzy
 msgid ""
 "If an exception occurs which does not match the exception named in the "
 "*except clause*, it is passed on to outer :keyword:`try` statements; if no "
@@ -200,7 +198,6 @@ msgstr ""
 "comme indiqué ci-dessus."
 
 #: tutorial/errors.rst:114
-#, fuzzy
 msgid ""
 "A :keyword:`try` statement may have more than one *except clause*, to "
 "specify handlers for different exceptions.  At most one handler will be "
@@ -218,7 +215,6 @@ msgstr ""
 "d'un *n*-uplet entre parenthèses, comme dans cet exemple ::"
 
 #: tutorial/errors.rst:123
-#, fuzzy
 msgid ""
 "A class in an :keyword:`except` clause is compatible with an exception if it "
 "is the same class or a base class thereof (but not the other way around --- "
@@ -232,7 +228,6 @@ msgstr ""
 "suivant affiche B, C et D dans cet ordre ::"
 
 #: tutorial/errors.rst:147
-#, fuzzy
 msgid ""
 "Note that if the *except clauses* were reversed (with ``except B`` first), "
 "it would have printed B, B, B --- the first matching *except clause* is "
@@ -243,7 +238,6 @@ msgstr ""
 "correspond est déclenchée."
 
 #: tutorial/errors.rst:150
-#, fuzzy
 msgid ""
 "All exceptions inherit from :exc:`BaseException`, and so it can be used to "
 "serve as a wildcard. Use this with extreme caution, since it is easy to mask "
@@ -251,8 +245,8 @@ msgid ""
 "message and then re-raise the exception (allowing a caller to handle the "
 "exception as well)::"
 msgstr ""
-"La dernière clause ``except`` peut omettre le(s) nom(s) d'exception(s) et "
-"joue alors le rôle de joker. C'est toutefois à utiliser avec beaucoup de "
+"Toutes les exceptions héritent de :exc:`BaseException`, il est donc possible "
+"de s'en servir comme un joker. C'est toutefois à utiliser avec beaucoup de "
 "précautions car il est facile de masquer une vraie erreur de programmation "
 "par ce biais. Elle peut aussi être utilisée pour afficher un message "
 "d'erreur avant de propager l'exception (en permettant à un appelant de gérer "
@@ -265,7 +259,6 @@ msgid ""
 msgstr ""
 
 #: tutorial/errors.rst:172
-#, fuzzy
 msgid ""
 "The :keyword:`try` ... :keyword:`except` statement has an optional *else "
 "clause*, which, when present, must follow all *except clauses*.  It is "
@@ -273,7 +266,7 @@ msgid ""
 "exception. For example::"
 msgstr ""
 "L'instruction :keyword:`try` ... :keyword:`except` accepte également une "
-"*clause else* optionnelle qui, lorsqu'elle est présente, doit se placer "
+"clause ``else`` optionnelle qui, lorsqu'elle est présente, doit se placer "
 "après toutes les clauses ``except``. Elle est utile pour du code qui doit "
 "être exécuté lorsqu'aucune exception n'a été levée par la clause ``try``. "
 "Par exemple ::"
@@ -301,7 +294,6 @@ msgstr ""
 "dépendent du type de l'exception."
 
 #: tutorial/errors.rst:195
-#, fuzzy
 msgid ""
 "The *except clause* may specify a variable after the exception name.  The "
 "variable is bound to an exception instance with the arguments stored in "
@@ -327,7 +319,6 @@ msgstr ""
 "message des exceptions non gérées."
 
 #: tutorial/errors.rst:222
-#, fuzzy
 msgid ""
 "Exception handlers don't just handle exceptions if they occur immediately in "
 "the *try clause*, but also if they occur inside functions that are called "
@@ -391,7 +382,6 @@ msgstr ""
 "Cela peut être utile lorsque vous transformez des exceptions. Par exemple ::"
 
 #: tutorial/errors.rst:305
-#, fuzzy
 msgid ""
 "Exception chaining happens automatically when an exception is raised inside "
 "an :keyword:`except` or :keyword:`finally` section. This can be disabled by "


### PR DESCRIPTION
Beaucoup de fuzzies dans ce fichier viennent du fait qu'ils ont mis en italique beaucoup de "clause machin" (try, except, else, finally).

Mais en français on les avait déjà mis en police à pas fixe, donc je n'y ai pas touché, sauf à un endroit ou c'était en italique, alors j'ai mis en police a pas fix pour garder la cohérence.