### PR TITLE
Suppression de build/ dans make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,9 @@
 # - make verifs  # To check for correctness: wrapping, spelling
 # - make wrap  # To check for wrapping
 # - make spell  # To check for spelling
-# - make merge  # To merge pot from upstream
+# - make clean # To remove build artifacts
 # - make fuzzy  # To find fuzzy strings
+# - make merge  # To merge pot from upstream
 #
 # Modes are: autobuild-stable, autobuild-dev, and autobuild-html,
 # documented in gen/src/3.6/Doc/Makefile as we're only delegating the
@@ -148,3 +149,5 @@ clean:
 	@echo "Cleaning *.mo and $(POSPELL_TMP_DIR)"
 	rm -fr $(POSPELL_TMP_DIR)
 	find -name '*.mo' -delete
+	@echo "Cleaning build directory"
+	$(MAKE) -C venv/cpython/Doc/ clean


### PR DESCRIPTION
Le but de make clean est de repartir à zéro, donc je propose de le
faire vraiment en supprimant, en plus des fichiers .mo et des fichiers
qui marquent les dépendances pour pospell, tout le dossier build/ avec
la documentation générée par Sphinx. C'est utile lorsque Sphinx oublie
de mettre à jour certaines choses, ou lorsque l'on se demande si c'est
le cas.