### PR TITLE
Mise à jour de EXCLUDED

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -316,12 +316,17 @@ Vous pouvez utiliser `potodo`_, un outil fait pour trouver des fichiers *po*
 à traduire. Une fois installé, utilisez la commande ``make todo`` dans votre clone
 local.
 
-Vous pouvez choisir n'importe quel fichier non réservé dans la liste
-renvoyée par la commande **à l'exception** des fichiers de :
+Vous pouvez choisir n'importe quel fichier non réservé dans la liste renvoyée.
+Elle contient tous les fichiers qui ne sont pas encore complètement traduits, à
+l'exception des fichiers de :
 
 - *c-api/* car c'est une partie très technique ;
-- *whatsnew/* car les anciennes versions de Python sont pour la plupart obsolètes et leurs journaux de modifications ne sont pas les pages les plus consultées ;
-- *distutils/* et *install/* car ces pages seront bientôt obsolètes.
+- *whatsnew/* car les anciennes versions de Python sont pour la plupart
+  obsolètes et leurs journaux de modifications ne sont pas les pages les plus
+  consultées ;
+- *distutils/*, *install/*, et quelques autres parties qui seront bientôt
+  obsolètes. De manière générale, il n'est pas utile de traduire un module que
+  sa documentation mentionne comme obsolète.
 
 Vous pouvez commencer par des tâches faciles comme réviser les entrées
 *fuzzy* pour aider à garder la documentation à jour (trouvez-les à l'aide

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,15 @@ CPYTHON_CURRENT_COMMIT := d5feb2b1f12a15c1a9bac094a8f6f77d0cfcbdc2
 LANGUAGE := fr
 BRANCH := 3.10
 
-EXCLUDED := whatsnew/ c-api/
+EXCLUDED := \
+	whatsnew/ \
+	c-api/ \
+	distutils/ \
+	install/ \
+	library/2to3.po \
+	library/distutils.po \
+	library/imp.po \
+	library/tkinter.tix \
 
 # Internal variables
 


### PR DESCRIPTION
Puisque CONTRIBUTING.rst recommande de ne pas traduire distutils/ et
installing/, ce commit les ajoute à EXCLUDED pour que Potodo les
ignore, ainsi que quelques modules marqués « .. deprecated:: »
upstream.