### PR TITLE
Fix link to the AFPY website's forums

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Vous pouvez contribuer :
 
 - en proposant des *pull requests* Github (solution recommandée) ;
 - en remontant des erreurs et propositions d'amélioration sur
-  le `forum de l'AFPy <https://discuss.afpy.or/c/traduction/>`_ ou sur la
+  le `forum de l'AFPy <https://discuss.afpy.org/c/traduction/>`_ ou sur la
   `liste de diffusion <https://lists.afpy.org/mailman/listinfo/traductions>`_ ;
 - en devenant `membre <https://www.afpy.org/adhesions>`_ de l'AFPy ou
   `mécène <https://liberapay.com/python-docs-fr>`_ du projet.


### PR DESCRIPTION
Add missing "g" in "discuss.afpy.org" link in the README