### PR TITLE
Traduction de library/functions.po

### DIFF
--- a/library/functions.po
+++ b/library/functions.po
@@ -2434,7 +2434,7 @@ msgid ""
 msgstr ""
 "Lors de l'écriture, si *newline* est ``None``, chaque ``'\\n'`` est remplacé "
 "par le séparateur de lignes par défaut du système :data:`os.linesep`. Si "
-"*newline* est ``*`` ou ``'\\n'`` aucun remplacement n'est effectué. Si "
+"*newline* est ``''`` ou ``'\\n'`` aucun remplacement n'est effectué. Si "
 "*newline* est un autre caractère valide, chaque ``'\\n'`` sera remplacé par "
 "la chaîne donnée."
 


### PR DESCRIPTION
Correction d'une typo dans `functions.po`