### PR TITLE
library/secrets.po: unfuzzy a string

### DIFF
--- a/library/secrets.po
+++ b/library/secrets.po
@@ -37,7 +37,6 @@ msgstr ""
 "secrets associés."
 
 #: library/secrets.rst:24
-#, fuzzy
 msgid ""
 "In particular, :mod:`secrets` should be used in preference to the default "
 "pseudo-random number generator in the :mod:`random` module, which is "


### PR DESCRIPTION
Le changement upstream est une correction de grammaire : python/cpython@git@63298930fb531ba2bb4f23bc3b915dbf1e17e9e1

