### PR TITLE
auto fill reStructuredText-only strings

### DIFF
--- a/c-api/bytes.po
+++ b/c-api/bytes.po
@@ -96,7 +96,7 @@ msgstr "Commentaires"
 
 #: c-api/bytes.rst:70
 msgid ":attr:`%%`"
-msgstr ""
+msgstr ":attr:`%%`"
 
 #: c-api/bytes.rst:70
 msgid "*n/a*"
@@ -108,7 +108,7 @@ msgstr ""
 
 #: c-api/bytes.rst:72
 msgid ":attr:`%c`"
-msgstr ""
+msgstr ":attr:`%c`"
 
 #: c-api/bytes.rst:75 c-api/bytes.rst:96
 msgid "int"
@@ -120,7 +120,7 @@ msgstr ""
 
 #: c-api/bytes.rst:75
 msgid ":attr:`%d`"
-msgstr ""
+msgstr ":attr:`%d`"
 
 #: c-api/bytes.rst:75
 msgid "Equivalent to ``printf(\"%d\")``. [1]_"
@@ -128,7 +128,7 @@ msgstr ""
 
 #: c-api/bytes.rst:78
 msgid ":attr:`%u`"
-msgstr ""
+msgstr ":attr:`%u`"
 
 #: c-api/bytes.rst:78
 msgid "unsigned int"
@@ -140,7 +140,7 @@ msgstr ""
 
 #: c-api/bytes.rst:81
 msgid ":attr:`%ld`"
-msgstr ""
+msgstr ":attr:`%ld`"
 
 #: c-api/bytes.rst:81
 msgid "long"
@@ -152,7 +152,7 @@ msgstr ""
 
 #: c-api/bytes.rst:84
 msgid ":attr:`%lu`"
-msgstr ""
+msgstr ":attr:`%lu`"
 
 #: c-api/bytes.rst:84
 msgid "unsigned long"
@@ -164,7 +164,7 @@ msgstr ""
 
 #: c-api/bytes.rst:87
 msgid ":attr:`%zd`"
-msgstr ""
+msgstr ":attr:`%zd`"
 
 #: c-api/bytes.rst:87
 msgid "Py_ssize_t"
@@ -176,7 +176,7 @@ msgstr ""
 
 #: c-api/bytes.rst:90
 msgid ":attr:`%zu`"
-msgstr ""
+msgstr ":attr:`%zu`"
 
 #: c-api/bytes.rst:90
 msgid "size_t"
@@ -188,7 +188,7 @@ msgstr ""
 
 #: c-api/bytes.rst:93
 msgid ":attr:`%i`"
-msgstr ""
+msgstr ":attr:`%i`"
 
 #: c-api/bytes.rst:93
 msgid "Equivalent to ``printf(\"%i\")``. [1]_"
@@ -196,7 +196,7 @@ msgstr ""
 
 #: c-api/bytes.rst:96
 msgid ":attr:`%x`"
-msgstr ""
+msgstr ":attr:`%x`"
 
 #: c-api/bytes.rst:96
 msgid "Equivalent to ``printf(\"%x\")``. [1]_"
@@ -204,7 +204,7 @@ msgstr ""
 
 #: c-api/bytes.rst:99
 msgid ":attr:`%s`"
-msgstr ""
+msgstr ":attr:`%s`"
 
 #: c-api/bytes.rst:99
 msgid "const char\\*"
@@ -216,7 +216,7 @@ msgstr ""
 
 #: c-api/bytes.rst:102
 msgid ":attr:`%p`"
-msgstr ""
+msgstr ":attr:`%p`"
 
 #: c-api/bytes.rst:102
 msgid "const void\\*"

--- a/c-api/exceptions.po
+++ b/c-api/exceptions.po
@@ -1121,7 +1121,7 @@ msgstr ":c:data:`PyExc_ModuleNotFoundError`."
 
 #: c-api/exceptions.rst:946
 msgid ":exc:`ModuleNotFoundError`"
-msgstr ""
+msgstr ":exc:`ModuleNotFoundError`"
 
 #: c-api/exceptions.rst:948
 msgid ":c:data:`PyExc_NameError`"
@@ -1185,7 +1185,7 @@ msgstr ":c:data:`PyExc_ReferenceError`"
 
 #: c-api/exceptions.rst:962
 msgid ":exc:`RecursionError`"
-msgstr ""
+msgstr ":exc:`RecursionError`"
 
 #: c-api/exceptions.rst:964
 msgid ":c:data:`PyExc_ReferenceError`"

--- a/c-api/init.po
+++ b/c-api/init.po
@@ -1701,7 +1701,7 @@ msgstr ""
 
 #: c-api/init.rst:1507
 msgid ":const:`PyTrace_CALL`"
-msgstr ""
+msgstr ":const:`PyTrace_CALL`"
 
 #: c-api/init.rst:1512 c-api/init.rst:1523
 msgid "Always :c:data:`Py_None`."
@@ -1709,7 +1709,7 @@ msgstr ""
 
 #: c-api/init.rst:1509
 msgid ":const:`PyTrace_EXCEPTION`"
-msgstr ""
+msgstr ":const:`PyTrace_EXCEPTION`"
 
 #: c-api/init.rst:1509
 msgid "Exception information as returned by :func:`sys.exc_info`."
@@ -1717,11 +1717,11 @@ msgstr ""
 
 #: c-api/init.rst:1512
 msgid ":const:`PyTrace_LINE`"
-msgstr ""
+msgstr ":const:`PyTrace_LINE`"
 
 #: c-api/init.rst:1514
 msgid ":const:`PyTrace_RETURN`"
-msgstr ""
+msgstr ":const:`PyTrace_RETURN`"
 
 #: c-api/init.rst:1514
 msgid ""
@@ -1730,7 +1730,7 @@ msgstr ""
 
 #: c-api/init.rst:1517
 msgid ":const:`PyTrace_C_CALL`"
-msgstr ""
+msgstr ":const:`PyTrace_C_CALL`"
 
 #: c-api/init.rst:1519 c-api/init.rst:1521
 msgid "Function object being called."
@@ -1738,15 +1738,15 @@ msgstr ""
 
 #: c-api/init.rst:1519
 msgid ":const:`PyTrace_C_EXCEPTION`"
-msgstr ""
+msgstr ":const:`PyTrace_C_EXCEPTION`"
 
 #: c-api/init.rst:1521
 msgid ":const:`PyTrace_C_RETURN`"
-msgstr ""
+msgstr ":const:`PyTrace_C_RETURN`"
 
 #: c-api/init.rst:1523
 msgid ":const:`PyTrace_OPCODE`"
-msgstr ""
+msgstr ":const:`PyTrace_OPCODE`"
 
 #: c-api/init.rst:1528
 msgid ""

--- a/c-api/structures.po
+++ b/c-api/structures.po
@@ -226,7 +226,7 @@ msgstr "Signification"
 
 #: c-api/structures.rst:241
 msgid ":attr:`ml_name`"
-msgstr ""
+msgstr ":attr:`ml_name`"
 
 #: c-api/structures.rst:249 c-api/structures.rst:412 c-api/structures.rst:495
 #: c-api/structures.rst:503
@@ -239,7 +239,7 @@ msgstr ""
 
 #: c-api/structures.rst:243
 msgid ":attr:`ml_meth`"
-msgstr ""
+msgstr ":attr:`ml_meth`"
 
 #: c-api/structures.rst:243
 msgid "PyCFunction"
@@ -251,7 +251,7 @@ msgstr ""
 
 #: c-api/structures.rst:246
 msgid ":attr:`ml_flags`"
-msgstr ""
+msgstr ":attr:`ml_flags`"
 
 #: c-api/structures.rst:401 c-api/structures.rst:424
 msgid "int"
@@ -263,7 +263,7 @@ msgstr ""
 
 #: c-api/structures.rst:249
 msgid ":attr:`ml_doc`"
-msgstr ""
+msgstr ":attr:`ml_doc`"
 
 #: c-api/structures.rst:412
 msgid "points to the contents of the docstring"
@@ -423,7 +423,7 @@ msgstr ""
 
 #: c-api/structures.rst:399
 msgid ":attr:`name`"
-msgstr ""
+msgstr ":attr:`name`"
 
 #: c-api/structures.rst:399
 msgid "name of the member"
@@ -431,7 +431,7 @@ msgstr ""
 
 #: c-api/structures.rst:401
 msgid ":attr:`!type`"
-msgstr ""
+msgstr ":attr:`!type`"
 
 #: c-api/structures.rst:401
 msgid "the type of the member in the C struct"
@@ -439,7 +439,7 @@ msgstr ""
 
 #: c-api/structures.rst:404
 msgid ":attr:`offset`"
-msgstr ""
+msgstr ":attr:`offset`"
 
 #: c-api/structures.rst:440
 msgid "Py_ssize_t"
@@ -452,7 +452,7 @@ msgstr ""
 
 #: c-api/structures.rst:408
 msgid ":attr:`flags`"
-msgstr ""
+msgstr ":attr:`flags`"
 
 #: c-api/structures.rst:408
 msgid "flag bits indicating if the field should be read-only or writable"
@@ -460,7 +460,7 @@ msgstr ""
 
 #: c-api/structures.rst:412
 msgid ":attr:`doc`"
-msgstr ""
+msgstr ":attr:`doc`"
 
 #: c-api/structures.rst:416
 msgid ""

--- a/c-api/typeobj.po
+++ b/c-api/typeobj.po
@@ -171,7 +171,7 @@ msgstr ""
 
 #: c-api/typeobj.rst:64 c-api/typeobj.rst:68
 msgid ":ref:`sub-slots`"
-msgstr ""
+msgstr ":ref:`sub-slots`"
 
 #: c-api/typeobj.rst:64 c-api/typeobj.rst:68 c-api/typeobj.rst:82
 msgid "%"
@@ -2147,7 +2147,7 @@ msgstr "Comparaison"
 
 #: c-api/typeobj.rst:1440
 msgid ":const:`Py_LT`"
-msgstr ""
+msgstr ":const:`Py_LT`"
 
 #: c-api/typeobj.rst:1440
 msgid "``<``"
@@ -2155,7 +2155,7 @@ msgstr "``<``"
 
 #: c-api/typeobj.rst:1442
 msgid ":const:`Py_LE`"
-msgstr ""
+msgstr ":const:`Py_LE`"
 
 #: c-api/typeobj.rst:1442
 msgid "``<=``"
@@ -2163,7 +2163,7 @@ msgstr "``<=``"
 
 #: c-api/typeobj.rst:1444
 msgid ":const:`Py_EQ`"
-msgstr ""
+msgstr ":const:`Py_EQ`"
 
 #: c-api/typeobj.rst:1444
 msgid "``==``"
@@ -2171,7 +2171,7 @@ msgstr "``==``"
 
 #: c-api/typeobj.rst:1446
 msgid ":const:`Py_NE`"
-msgstr ""
+msgstr ":const:`Py_NE`"
 
 #: c-api/typeobj.rst:1446
 msgid "``!=``"
@@ -2179,7 +2179,7 @@ msgstr "``!=``"
 
 #: c-api/typeobj.rst:1448
 msgid ":const:`Py_GT`"
-msgstr ""
+msgstr ":const:`Py_GT`"
 
 #: c-api/typeobj.rst:1448
 msgid "``>``"
@@ -2187,7 +2187,7 @@ msgstr "``>``"
 
 #: c-api/typeobj.rst:1450
 msgid ":const:`Py_GE`"
-msgstr ""
+msgstr ":const:`Py_GE`"
 
 #: c-api/typeobj.rst:1450
 msgid "``>=``"

--- a/c-api/unicode.po
+++ b/c-api/unicode.po
@@ -472,7 +472,7 @@ msgstr "Commentaires"
 
 #: c-api/unicode.rst:464
 msgid ":attr:`%%`"
-msgstr ""
+msgstr ":attr:`%%`"
 
 #: c-api/unicode.rst:464
 msgid "*n/a*"
@@ -484,7 +484,7 @@ msgstr ""
 
 #: c-api/unicode.rst:466
 msgid ":attr:`%c`"
-msgstr ""
+msgstr ":attr:`%c`"
 
 #: c-api/unicode.rst:469 c-api/unicode.rst:505
 msgid "int"
@@ -496,7 +496,7 @@ msgstr ""
 
 #: c-api/unicode.rst:469
 msgid ":attr:`%d`"
-msgstr ""
+msgstr ":attr:`%d`"
 
 #: c-api/unicode.rst:469
 msgid "Equivalent to ``printf(\"%d\")``. [1]_"
@@ -504,7 +504,7 @@ msgstr ""
 
 #: c-api/unicode.rst:472
 msgid ":attr:`%u`"
-msgstr ""
+msgstr ":attr:`%u`"
 
 #: c-api/unicode.rst:472
 msgid "unsigned int"
@@ -516,7 +516,7 @@ msgstr ""
 
 #: c-api/unicode.rst:475
 msgid ":attr:`%ld`"
-msgstr ""
+msgstr ":attr:`%ld`"
 
 #: c-api/unicode.rst:478
 msgid "long"
@@ -528,7 +528,7 @@ msgstr ""
 
 #: c-api/unicode.rst:478
 msgid ":attr:`%li`"
-msgstr ""
+msgstr ":attr:`%li`"
 
 #: c-api/unicode.rst:478
 msgid "Equivalent to ``printf(\"%li\")``. [1]_"
@@ -536,7 +536,7 @@ msgstr ""
 
 #: c-api/unicode.rst:481
 msgid ":attr:`%lu`"
-msgstr ""
+msgstr ":attr:`%lu`"
 
 #: c-api/unicode.rst:481
 msgid "unsigned long"
@@ -548,7 +548,7 @@ msgstr ""
 
 #: c-api/unicode.rst:484
 msgid ":attr:`%lld`"
-msgstr ""
+msgstr ":attr:`%lld`"
 
 #: c-api/unicode.rst:487
 msgid "long long"
@@ -560,7 +560,7 @@ msgstr ""
 
 #: c-api/unicode.rst:487
 msgid ":attr:`%lli`"
-msgstr ""
+msgstr ":attr:`%lli`"
 
 #: c-api/unicode.rst:487
 msgid "Equivalent to ``printf(\"%lli\")``. [1]_"
@@ -568,7 +568,7 @@ msgstr ""
 
 #: c-api/unicode.rst:490
 msgid ":attr:`%llu`"
-msgstr ""
+msgstr ":attr:`%llu`"
 
 #: c-api/unicode.rst:490
 msgid "unsigned long long"
@@ -580,7 +580,7 @@ msgstr ""
 
 #: c-api/unicode.rst:493
 msgid ":attr:`%zd`"
-msgstr ""
+msgstr ":attr:`%zd`"
 
 #: c-api/unicode.rst:496
 msgid "Py_ssize_t"
@@ -592,7 +592,7 @@ msgstr ""
 
 #: c-api/unicode.rst:496
 msgid ":attr:`%zi`"
-msgstr ""
+msgstr ":attr:`%zi`"
 
 #: c-api/unicode.rst:496
 msgid "Equivalent to ``printf(\"%zi\")``. [1]_"
@@ -600,7 +600,7 @@ msgstr ""
 
 #: c-api/unicode.rst:499
 msgid ":attr:`%zu`"
-msgstr ""
+msgstr ":attr:`%zu`"
 
 #: c-api/unicode.rst:499
 msgid "size_t"
@@ -612,7 +612,7 @@ msgstr ""
 
 #: c-api/unicode.rst:502
 msgid ":attr:`%i`"
-msgstr ""
+msgstr ":attr:`%i`"
 
 #: c-api/unicode.rst:502
 msgid "Equivalent to ``printf(\"%i\")``. [1]_"
@@ -620,7 +620,7 @@ msgstr ""
 
 #: c-api/unicode.rst:505
 msgid ":attr:`%x`"
-msgstr ""
+msgstr ":attr:`%x`"
 
 #: c-api/unicode.rst:505
 msgid "Equivalent to ``printf(\"%x\")``. [1]_"
@@ -628,7 +628,7 @@ msgstr ""
 
 #: c-api/unicode.rst:508
 msgid ":attr:`%s`"
-msgstr ""
+msgstr ":attr:`%s`"
 
 #: c-api/unicode.rst:508
 msgid "const char\\*"
@@ -640,7 +640,7 @@ msgstr ""
 
 #: c-api/unicode.rst:511
 msgid ":attr:`%p`"
-msgstr ""
+msgstr ":attr:`%p`"
 
 #: c-api/unicode.rst:511
 msgid "const void\\*"
@@ -655,7 +655,7 @@ msgstr ""
 
 #: c-api/unicode.rst:519
 msgid ":attr:`%A`"
-msgstr ""
+msgstr ":attr:`%A`"
 
 #: c-api/unicode.rst:522 c-api/unicode.rst:534
 msgid "PyObject\\*"
@@ -667,7 +667,7 @@ msgstr ""
 
 #: c-api/unicode.rst:522
 msgid ":attr:`%U`"
-msgstr ""
+msgstr ":attr:`%U`"
 
 #: c-api/unicode.rst:522
 #, fuzzy
@@ -676,7 +676,7 @@ msgstr "Un objet Unicode."
 
 #: c-api/unicode.rst:524
 msgid ":attr:`%V`"
-msgstr ""
+msgstr ":attr:`%V`"
 
 #: c-api/unicode.rst:524
 msgid "PyObject\\*, const char\\*"
@@ -691,7 +691,7 @@ msgstr ""
 
 #: c-api/unicode.rst:531
 msgid ":attr:`%S`"
-msgstr ""
+msgstr ":attr:`%S`"
 
 #: c-api/unicode.rst:531
 msgid "The result of calling :c:func:`PyObject_Str`."
@@ -699,7 +699,7 @@ msgstr ""
 
 #: c-api/unicode.rst:534
 msgid ":attr:`%R`"
-msgstr ""
+msgstr ":attr:`%R`"
 
 #: c-api/unicode.rst:534
 msgid "The result of calling :c:func:`PyObject_Repr`."

--- a/install/index.po
+++ b/install/index.po
@@ -1290,7 +1290,7 @@ msgstr ""
 
 #: install/index.rst:744
 msgid ":file:`{prefix}/lib/python{ver}/distutils/distutils.cfg`"
-msgstr ""
+msgstr ":file:`{prefix}/lib/python{ver}/distutils/distutils.cfg`"
 
 #: install/index.rst:758
 msgid "personal"
@@ -1298,7 +1298,7 @@ msgstr ""
 
 #: install/index.rst:746
 msgid ":file:`$HOME/.pydistutils.cfg`"
-msgstr ""
+msgstr ":file:`$HOME/.pydistutils.cfg`"
 
 #: install/index.rst:760
 msgid "local"
@@ -1306,7 +1306,7 @@ msgstr ""
 
 #: install/index.rst:760
 msgid ":file:`setup.cfg`"
-msgstr ""
+msgstr ":file:`setup.cfg`"
 
 #: install/index.rst:760
 msgid "\\(3)"
@@ -1318,7 +1318,7 @@ msgstr ""
 
 #: install/index.rst:756
 msgid ":file:`{prefix}\\\\Lib\\\\distutils\\\\distutils.cfg`"
-msgstr ""
+msgstr ":file:`{prefix}\\\\Lib\\\\distutils\\\\distutils.cfg`"
 
 #: install/index.rst:756
 msgid "\\(4)"
@@ -1326,7 +1326,7 @@ msgstr "\\(4)"
 
 #: install/index.rst:758
 msgid ":file:`%HOME%\\\\pydistutils.cfg`"
-msgstr ""
+msgstr ":file:`%HOME%\\\\pydistutils.cfg`"
 
 #: install/index.rst:758
 msgid "\\(5)"

--- a/library/asyncio-api-index.po
+++ b/library/asyncio-api-index.po
@@ -43,7 +43,7 @@ msgstr ""
 
 #: library/asyncio-api-index.rst:24
 msgid ":func:`create_task`"
-msgstr ""
+msgstr ":func:`create_task`"
 
 #: library/asyncio-api-index.rst:25
 msgid "Start an asyncio Task."
@@ -91,7 +91,7 @@ msgstr ""
 
 #: library/asyncio-api-index.rst:42
 msgid ":func:`current_task`"
-msgstr ""
+msgstr ":func:`current_task`"
 
 #: library/asyncio-api-index.rst:43
 msgid "Return the current Task."
@@ -99,7 +99,7 @@ msgstr ""
 
 #: library/asyncio-api-index.rst:45
 msgid ":func:`all_tasks`"
-msgstr ""
+msgstr ":func:`all_tasks`"
 
 #: library/asyncio-api-index.rst:46
 msgid "Return all tasks for an event loop."
@@ -107,7 +107,7 @@ msgstr ""
 
 #: library/asyncio-api-index.rst:48
 msgid ":class:`Task`"
-msgstr ""
+msgstr ":class:`Task`"
 
 #: library/asyncio-api-index.rst:49
 msgid "Task object."
@@ -124,7 +124,7 @@ msgstr ""
 
 #: library/asyncio-api-index.rst:54
 msgid ":func:`run_coroutine_threadsafe`"
-msgstr ""
+msgstr ":func:`run_coroutine_threadsafe`"
 
 #: library/asyncio-api-index.rst:55
 msgid "Schedule a coroutine from another OS thread."
@@ -286,7 +286,7 @@ msgstr ""
 
 #: library/asyncio-api-index.rst:150
 msgid ":class:`StreamReader`"
-msgstr ""
+msgstr ":class:`StreamReader`"
 
 #: library/asyncio-api-index.rst:151
 msgid "High-level async/await object to receive network data."
@@ -294,7 +294,7 @@ msgstr ""
 
 #: library/asyncio-api-index.rst:153
 msgid ":class:`StreamWriter`"
-msgstr ""
+msgstr ":class:`StreamWriter`"
 
 #: library/asyncio-api-index.rst:154
 msgid "High-level async/await object to send network data."
@@ -372,7 +372,7 @@ msgstr "Exceptions"
 
 #: library/asyncio-api-index.rst:206
 msgid ":exc:`asyncio.TimeoutError`"
-msgstr ""
+msgstr ":exc:`asyncio.TimeoutError`"
 
 #: library/asyncio-api-index.rst:207
 msgid ""
@@ -383,7 +383,7 @@ msgstr ""
 
 #: library/asyncio-api-index.rst:211
 msgid ":exc:`asyncio.CancelledError`"
-msgstr ""
+msgstr ":exc:`asyncio.CancelledError`"
 
 #: library/asyncio-api-index.rst:212
 msgid "Raised when a Task is cancelled. See also :meth:`Task.cancel`."

--- a/library/asyncio-llapi-index.po
+++ b/library/asyncio-llapi-index.po
@@ -28,7 +28,7 @@ msgstr "Obtenir une boucle d'évènements"
 
 #: library/asyncio-llapi-index.rst:18
 msgid ":func:`asyncio.get_running_loop`"
-msgstr ""
+msgstr ":func:`asyncio.get_running_loop`"
 
 #: library/asyncio-llapi-index.rst:19
 msgid "The **preferred** function to get the running event loop."
@@ -36,7 +36,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:21
 msgid ":func:`asyncio.get_event_loop`"
-msgstr ""
+msgstr ":func:`asyncio.get_event_loop`"
 
 #: library/asyncio-llapi-index.rst:22
 msgid "Get an event loop instance (current or via the policy)."
@@ -44,7 +44,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:24
 msgid ":func:`asyncio.set_event_loop`"
-msgstr ""
+msgstr ":func:`asyncio.set_event_loop`"
 
 #: library/asyncio-llapi-index.rst:25
 msgid "Set the event loop as current via the current policy."
@@ -52,7 +52,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:27
 msgid ":func:`asyncio.new_event_loop`"
-msgstr ""
+msgstr ":func:`asyncio.new_event_loop`"
 
 #: library/asyncio-llapi-index.rst:28
 msgid "Create a new event loop."
@@ -82,7 +82,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:47
 msgid ":meth:`loop.run_until_complete`"
-msgstr ""
+msgstr ":meth:`loop.run_until_complete`"
 
 #: library/asyncio-llapi-index.rst:48
 msgid "Run a Future/Task/awaitable until complete."
@@ -90,7 +90,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:50
 msgid ":meth:`loop.run_forever`"
-msgstr ""
+msgstr ":meth:`loop.run_forever`"
 
 #: library/asyncio-llapi-index.rst:51
 msgid "Run the event loop forever."
@@ -98,7 +98,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:53
 msgid ":meth:`loop.stop`"
-msgstr ""
+msgstr ":meth:`loop.stop`"
 
 #: library/asyncio-llapi-index.rst:54
 msgid "Stop the event loop."
@@ -106,7 +106,7 @@ msgstr "Arrête l'exécution de la boucle d'évènements."
 
 #: library/asyncio-llapi-index.rst:56
 msgid ":meth:`loop.close`"
-msgstr ""
+msgstr ":meth:`loop.close`"
 
 #: library/asyncio-llapi-index.rst:57
 msgid "Close the event loop."
@@ -114,7 +114,7 @@ msgstr "Arrête la boucle d'évènements."
 
 #: library/asyncio-llapi-index.rst:59
 msgid ":meth:`loop.is_running()`"
-msgstr ""
+msgstr ":meth:`loop.is_running()`"
 
 #: library/asyncio-llapi-index.rst:60
 msgid "Return ``True`` if the event loop is running."
@@ -122,7 +122,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:62
 msgid ":meth:`loop.is_closed()`"
-msgstr ""
+msgstr ":meth:`loop.is_closed()`"
 
 #: library/asyncio-llapi-index.rst:63
 #, fuzzy
@@ -143,7 +143,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:74
 msgid ":meth:`loop.set_debug`"
-msgstr ""
+msgstr ":meth:`loop.set_debug`"
 
 #: library/asyncio-llapi-index.rst:75
 msgid "Enable or disable the debug mode."
@@ -151,7 +151,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:77
 msgid ":meth:`loop.get_debug`"
-msgstr ""
+msgstr ":meth:`loop.get_debug`"
 
 #: library/asyncio-llapi-index.rst:78
 msgid "Get the current debug mode."
@@ -163,7 +163,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:86
 msgid ":meth:`loop.call_soon`"
-msgstr ""
+msgstr ":meth:`loop.call_soon`"
 
 #: library/asyncio-llapi-index.rst:87
 msgid "Invoke a callback soon."
@@ -171,7 +171,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:89
 msgid ":meth:`loop.call_soon_threadsafe`"
-msgstr ""
+msgstr ":meth:`loop.call_soon_threadsafe`"
 
 #: library/asyncio-llapi-index.rst:90
 msgid "A thread-safe variant of :meth:`loop.call_soon`."
@@ -179,7 +179,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:92
 msgid ":meth:`loop.call_later`"
-msgstr ""
+msgstr ":meth:`loop.call_later`"
 
 #: library/asyncio-llapi-index.rst:93
 msgid "Invoke a callback *after* the given time."
@@ -187,7 +187,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:95
 msgid ":meth:`loop.call_at`"
-msgstr ""
+msgstr ":meth:`loop.call_at`"
 
 #: library/asyncio-llapi-index.rst:96
 msgid "Invoke a callback *at* the given time."
@@ -209,7 +209,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:108
 msgid ":meth:`loop.set_default_executor`"
-msgstr ""
+msgstr ":meth:`loop.set_default_executor`"
 
 #: library/asyncio-llapi-index.rst:109
 msgid "Set the default executor for :meth:`loop.run_in_executor`."
@@ -221,7 +221,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:117
 msgid ":meth:`loop.create_future`"
-msgstr ""
+msgstr ":meth:`loop.create_future`"
 
 #: library/asyncio-llapi-index.rst:118
 msgid "Create a :class:`Future` object."
@@ -229,7 +229,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:120
 msgid ":meth:`loop.create_task`"
-msgstr ""
+msgstr ":meth:`loop.create_task`"
 
 #: library/asyncio-llapi-index.rst:121
 msgid "Schedule coroutine as a :class:`Task`."
@@ -237,7 +237,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:123
 msgid ":meth:`loop.set_task_factory`"
-msgstr ""
+msgstr ":meth:`loop.set_task_factory`"
 
 #: library/asyncio-llapi-index.rst:124
 msgid ""
@@ -247,7 +247,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:127
 msgid ":meth:`loop.get_task_factory`"
-msgstr ""
+msgstr ":meth:`loop.get_task_factory`"
 
 #: library/asyncio-llapi-index.rst:128
 msgid ""
@@ -413,7 +413,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:204
 msgid ":meth:`loop.add_reader`"
-msgstr ""
+msgstr ":meth:`loop.add_reader`"
 
 #: library/asyncio-llapi-index.rst:205
 msgid "Start watching a file descriptor for read availability."
@@ -421,7 +421,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:207
 msgid ":meth:`loop.remove_reader`"
-msgstr ""
+msgstr ":meth:`loop.remove_reader`"
 
 #: library/asyncio-llapi-index.rst:208
 msgid "Stop watching a file descriptor for read availability."
@@ -429,7 +429,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:210
 msgid ":meth:`loop.add_writer`"
-msgstr ""
+msgstr ":meth:`loop.add_writer`"
 
 #: library/asyncio-llapi-index.rst:211
 msgid "Start watching a file descriptor for write availability."
@@ -437,7 +437,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:213
 msgid ":meth:`loop.remove_writer`"
-msgstr ""
+msgstr ":meth:`loop.remove_writer`"
 
 #: library/asyncio-llapi-index.rst:214
 msgid "Stop watching a file descriptor for write availability."
@@ -450,7 +450,7 @@ msgstr "Signaux Unix"
 
 #: library/asyncio-llapi-index.rst:222
 msgid ":meth:`loop.add_signal_handler`"
-msgstr ""
+msgstr ":meth:`loop.add_signal_handler`"
 
 #: library/asyncio-llapi-index.rst:223
 msgid "Add a handler for a :mod:`signal`."
@@ -458,7 +458,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:225
 msgid ":meth:`loop.remove_signal_handler`"
-msgstr ""
+msgstr ":meth:`loop.remove_signal_handler`"
 
 #: library/asyncio-llapi-index.rst:226
 msgid "Remove a handler for a :mod:`signal`."
@@ -470,7 +470,7 @@ msgstr "Sous-processus"
 
 #: library/asyncio-llapi-index.rst:234
 msgid ":meth:`loop.subprocess_exec`"
-msgstr ""
+msgstr ":meth:`loop.subprocess_exec`"
 
 #: library/asyncio-llapi-index.rst:235
 msgid "Spawn a subprocess."
@@ -478,7 +478,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:237
 msgid ":meth:`loop.subprocess_shell`"
-msgstr ""
+msgstr ":meth:`loop.subprocess_shell`"
 
 #: library/asyncio-llapi-index.rst:238
 msgid "Spawn a subprocess from a shell command."
@@ -490,7 +490,7 @@ msgstr "Gestion des erreurs"
 
 #: library/asyncio-llapi-index.rst:246
 msgid ":meth:`loop.call_exception_handler`"
-msgstr ""
+msgstr ":meth:`loop.call_exception_handler`"
 
 #: library/asyncio-llapi-index.rst:247
 msgid "Call the exception handler."
@@ -498,7 +498,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:249
 msgid ":meth:`loop.set_exception_handler`"
-msgstr ""
+msgstr ":meth:`loop.set_exception_handler`"
 
 #: library/asyncio-llapi-index.rst:250
 msgid "Set a new exception handler."
@@ -506,7 +506,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:252
 msgid ":meth:`loop.get_exception_handler`"
-msgstr ""
+msgstr ":meth:`loop.get_exception_handler`"
 
 #: library/asyncio-llapi-index.rst:253
 msgid "Get the current exception handler."
@@ -514,7 +514,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:255
 msgid ":meth:`loop.default_exception_handler`"
-msgstr ""
+msgstr ":meth:`loop.default_exception_handler`"
 
 #: library/asyncio-llapi-index.rst:256
 msgid "The default exception handler implementation."
@@ -963,7 +963,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:503
 msgid ":meth:`asyncio.get_event_loop_policy`"
-msgstr ""
+msgstr ":meth:`asyncio.get_event_loop_policy`"
 
 #: library/asyncio-llapi-index.rst:504
 msgid "Return the current process-wide policy."
@@ -971,7 +971,7 @@ msgstr "Renvoie la stratégie actuelle à l'échelle du processus."
 
 #: library/asyncio-llapi-index.rst:506
 msgid ":meth:`asyncio.set_event_loop_policy`"
-msgstr ""
+msgstr ":meth:`asyncio.set_event_loop_policy`"
 
 #: library/asyncio-llapi-index.rst:507
 msgid "Set a new process-wide policy."
@@ -979,7 +979,7 @@ msgstr ""
 
 #: library/asyncio-llapi-index.rst:509
 msgid ":class:`AbstractEventLoopPolicy`"
-msgstr ""
+msgstr ":class:`AbstractEventLoopPolicy`"
 
 #: library/asyncio-llapi-index.rst:510
 msgid "Base class for policy objects."

--- a/library/datetime.po
+++ b/library/datetime.po
@@ -3131,7 +3131,7 @@ msgstr ""
 
 #: library/datetime.rst:2186
 msgid ":mod:`zoneinfo`"
-msgstr ""
+msgstr ":mod:`zoneinfo`"
 
 #: library/datetime.rst:2181
 #, fuzzy

--- a/library/importlib.po
+++ b/library/importlib.po
@@ -571,7 +571,7 @@ msgstr ""
 
 #: library/importlib.rst:436
 msgid ":attr:`__name__`"
-msgstr ""
+msgstr ":attr:`__name__`"
 
 #: library/importlib.rst:436
 msgid "The name of the module."
@@ -579,7 +579,7 @@ msgstr ""
 
 #: library/importlib.rst:440
 msgid ":attr:`__file__`"
-msgstr ""
+msgstr ":attr:`__file__`"
 
 #: library/importlib.rst:439
 msgid ""
@@ -588,7 +588,7 @@ msgstr ""
 
 #: library/importlib.rst:444
 msgid ":attr:`__cached__`"
-msgstr ""
+msgstr ":attr:`__cached__`"
 
 #: library/importlib.rst:443
 msgid ""
@@ -598,7 +598,7 @@ msgstr ""
 
 #: library/importlib.rst:448
 msgid ":attr:`__path__`"
-msgstr ""
+msgstr ":attr:`__path__`"
 
 #: library/importlib.rst:447
 msgid ""
@@ -608,7 +608,7 @@ msgstr ""
 
 #: library/importlib.rst:455
 msgid ":attr:`__package__`"
-msgstr ""
+msgstr ":attr:`__package__`"
 
 #: library/importlib.rst:451
 msgid ""
@@ -620,7 +620,7 @@ msgstr ""
 
 #: library/importlib.rst:460
 msgid ":attr:`__loader__`"
-msgstr ""
+msgstr ":attr:`__loader__`"
 
 #: library/importlib.rst:458
 msgid ""
@@ -918,11 +918,11 @@ msgstr ""
 
 #: library/importlib.rst:724
 msgid ":meth:`ResourceLoader.get_data`"
-msgstr ""
+msgstr ":meth:`ResourceLoader.get_data`"
 
 #: library/importlib.rst:727
 msgid ":meth:`ExecutionLoader.get_filename`"
-msgstr ""
+msgstr ":meth:`ExecutionLoader.get_filename`"
 
 #: library/importlib.rst:726
 msgid ""

--- a/library/io.po
+++ b/library/io.po
@@ -297,7 +297,7 @@ msgstr ""
 
 #: library/io.rst:237
 msgid ":mod:`sys`"
-msgstr ""
+msgstr ":mod:`sys`"
 
 #: library/io.rst:237
 msgid ""
@@ -390,7 +390,7 @@ msgstr ""
 
 #: library/io.rst:294 library/io.rst:298
 msgid ":class:`IOBase`"
-msgstr ""
+msgstr ":class:`IOBase`"
 
 #: library/io.rst:289
 msgid "``fileno``, ``seek``, and ``truncate``"
@@ -405,7 +405,7 @@ msgstr ""
 
 #: library/io.rst:294
 msgid ":class:`RawIOBase`"
-msgstr ""
+msgstr ":class:`RawIOBase`"
 
 #: library/io.rst:294
 msgid "``readinto`` and ``write``"
@@ -417,7 +417,7 @@ msgstr ""
 
 #: library/io.rst:296
 msgid ":class:`BufferedIOBase`"
-msgstr ""
+msgstr ":class:`BufferedIOBase`"
 
 #: library/io.rst:296
 msgid "``detach``, ``read``, ``read1``, and ``write``"
@@ -429,7 +429,7 @@ msgstr ""
 
 #: library/io.rst:298
 msgid ":class:`TextIOBase`"
-msgstr ""
+msgstr ":class:`TextIOBase`"
 
 #: library/io.rst:298
 msgid "``detach``, ``read``, ``readline``, and ``write``"

--- a/library/mailbox.po
+++ b/library/mailbox.po
@@ -418,7 +418,7 @@ msgstr ""
 
 #: library/mailbox.rst:299
 msgid ":class:`Maildir`"
-msgstr ""
+msgstr ":class:`Maildir`"
 
 #: library/mailbox.rst:304
 msgid ""
@@ -803,7 +803,7 @@ msgstr ""
 
 #: library/mailbox.rst:628
 msgid ":class:`Babyl`"
-msgstr ""
+msgstr ":class:`Babyl`"
 
 #: library/mailbox.rst:633
 msgid ""
@@ -996,7 +996,7 @@ msgstr ""
 
 #: library/mailbox.rst:794
 msgid ":class:`MaildirMessage`"
-msgstr ""
+msgstr ":class:`MaildirMessage`"
 
 #: library/mailbox.rst:799
 msgid ""
@@ -1303,7 +1303,7 @@ msgstr ""
 
 #: library/mailbox.rst:962
 msgid ":class:`mboxMessage`"
-msgstr ""
+msgstr ":class:`mboxMessage`"
 
 #: library/mailbox.rst:967
 msgid ""
@@ -1448,7 +1448,7 @@ msgstr ""
 
 #: library/mailbox.rst:1116
 msgid ":class:`MHMessage`"
-msgstr ""
+msgstr ":class:`MHMessage`"
 
 #: library/mailbox.rst:1121
 msgid ""
@@ -1535,7 +1535,7 @@ msgstr ""
 
 #: library/mailbox.rst:1206
 msgid ":class:`BabylMessage`"
-msgstr ""
+msgstr ":class:`BabylMessage`"
 
 #: library/mailbox.rst:1211
 msgid ""

--- a/library/optparse.po
+++ b/library/optparse.po
@@ -1908,7 +1908,7 @@ msgstr ""
 
 #: library/optparse.rst:1596
 msgid ":attr:`~Option.type`"
-msgstr ""
+msgstr ":attr:`~Option.type`"
 
 #: library/optparse.rst:1593
 msgid ""
@@ -1920,7 +1920,7 @@ msgstr ""
 
 #: library/optparse.rst:1602
 msgid ":attr:`~Option.nargs`"
-msgstr ""
+msgstr ":attr:`~Option.nargs`"
 
 #: library/optparse.rst:1599
 msgid ""
@@ -1932,7 +1932,7 @@ msgstr ""
 
 #: library/optparse.rst:1605
 msgid ":attr:`~Option.callback_args`"
-msgstr ""
+msgstr ":attr:`~Option.callback_args`"
 
 #: library/optparse.rst:1605
 msgid "a tuple of extra positional arguments to pass to the callback"
@@ -1940,7 +1940,7 @@ msgstr ""
 
 #: library/optparse.rst:1609
 msgid ":attr:`~Option.callback_kwargs`"
-msgstr ""
+msgstr ":attr:`~Option.callback_kwargs`"
 
 #: library/optparse.rst:1608
 msgid "a dictionary of extra keyword arguments to pass to the callback"

--- a/library/profile.po
+++ b/library/profile.po
@@ -906,7 +906,7 @@ msgstr ""
 
 #: library/profile.rst:678
 msgid ":class:`profile.Profile`"
-msgstr ""
+msgstr ":class:`profile.Profile`"
 
 #: library/profile.rst:665
 msgid ""
@@ -931,7 +931,7 @@ msgstr ""
 
 #: library/profile.rst:692
 msgid ":class:`cProfile.Profile`"
-msgstr ""
+msgstr ":class:`cProfile.Profile`"
 
 #: library/profile.rst:681
 msgid ""

--- a/library/select.po
+++ b/library/select.po
@@ -388,7 +388,7 @@ msgstr ""
 
 #: library/select.rst:301
 msgid ":const:`EPOLLEXCLUSIVE`"
-msgstr ""
+msgstr ":const:`EPOLLEXCLUSIVE`"
 
 #: library/select.rst:301
 msgid ""

--- a/library/smtplib.po
+++ b/library/smtplib.po
@@ -388,7 +388,7 @@ msgstr ""
 
 #: library/smtplib.rst:422 library/smtplib.rst:499
 msgid ":exc:`SMTPNotSupportedError`"
-msgstr ""
+msgstr ":exc:`SMTPNotSupportedError`"
 
 #: library/smtplib.rst:333
 msgid "The ``AUTH`` command is not supported by the server."
@@ -593,7 +593,7 @@ msgstr ""
 
 #: library/smtplib.rst:485
 msgid ":exc:`SMTPRecipientsRefused`"
-msgstr ""
+msgstr ":exc:`SMTPRecipientsRefused`"
 
 #: library/smtplib.rst:482
 msgid ""
@@ -605,7 +605,7 @@ msgstr ""
 
 #: library/smtplib.rst:491
 msgid ":exc:`SMTPSenderRefused`"
-msgstr ""
+msgstr ":exc:`SMTPSenderRefused`"
 
 #: library/smtplib.rst:491
 msgid "The server didn't accept the *from_addr*."

--- a/library/ssl.po
+++ b/library/ssl.po
@@ -1215,27 +1215,27 @@ msgstr ""
 
 #: library/ssl.rst:1114
 msgid ":meth:`~socket.socket.accept()`"
-msgstr ""
+msgstr ":meth:`~socket.socket.accept()`"
 
 #: library/ssl.rst:1115
 msgid ":meth:`~socket.socket.bind()`"
-msgstr ""
+msgstr ":meth:`~socket.socket.bind()`"
 
 #: library/ssl.rst:1116
 msgid ":meth:`~socket.socket.close()`"
-msgstr ""
+msgstr ":meth:`~socket.socket.close()`"
 
 #: library/ssl.rst:1117
 msgid ":meth:`~socket.socket.connect()`"
-msgstr ""
+msgstr ":meth:`~socket.socket.connect()`"
 
 #: library/ssl.rst:1118
 msgid ":meth:`~socket.socket.detach()`"
-msgstr ""
+msgstr ":meth:`~socket.socket.detach()`"
 
 #: library/ssl.rst:1119
 msgid ":meth:`~socket.socket.fileno()`"
-msgstr ""
+msgstr ":meth:`~socket.socket.fileno()`"
 
 #: library/ssl.rst:1120
 msgid ""
@@ -1255,11 +1255,11 @@ msgstr ""
 
 #: library/ssl.rst:1124
 msgid ":meth:`~socket.socket.listen()`"
-msgstr ""
+msgstr ":meth:`~socket.socket.listen()`"
 
 #: library/ssl.rst:1125
 msgid ":meth:`~socket.socket.makefile()`"
-msgstr ""
+msgstr ":meth:`~socket.socket.makefile()`"
 
 #: library/ssl.rst:1126
 msgid ""
@@ -1281,7 +1281,7 @@ msgstr ""
 
 #: library/ssl.rst:1132
 msgid ":meth:`~socket.socket.shutdown()`"
-msgstr ""
+msgstr ":meth:`~socket.socket.shutdown()`"
 
 #: library/ssl.rst:1134
 msgid ""
@@ -2761,79 +2761,79 @@ msgstr ""
 
 #: library/ssl.rst:2506
 msgid ":attr:`~SSLSocket.context`"
-msgstr ""
+msgstr ":attr:`~SSLSocket.context`"
 
 #: library/ssl.rst:2507
 msgid ":attr:`~SSLSocket.server_side`"
-msgstr ""
+msgstr ":attr:`~SSLSocket.server_side`"
 
 #: library/ssl.rst:2508
 msgid ":attr:`~SSLSocket.server_hostname`"
-msgstr ""
+msgstr ":attr:`~SSLSocket.server_hostname`"
 
 #: library/ssl.rst:2509
 msgid ":attr:`~SSLSocket.session`"
-msgstr ""
+msgstr ":attr:`~SSLSocket.session`"
 
 #: library/ssl.rst:2510
 msgid ":attr:`~SSLSocket.session_reused`"
-msgstr ""
+msgstr ":attr:`~SSLSocket.session_reused`"
 
 #: library/ssl.rst:2511
 msgid ":meth:`~SSLSocket.read`"
-msgstr ""
+msgstr ":meth:`~SSLSocket.read`"
 
 #: library/ssl.rst:2512
 msgid ":meth:`~SSLSocket.write`"
-msgstr ""
+msgstr ":meth:`~SSLSocket.write`"
 
 #: library/ssl.rst:2513
 msgid ":meth:`~SSLSocket.getpeercert`"
-msgstr ""
+msgstr ":meth:`~SSLSocket.getpeercert`"
 
 #: library/ssl.rst:2514
 msgid ":meth:`~SSLSocket.selected_alpn_protocol`"
-msgstr ""
+msgstr ":meth:`~SSLSocket.selected_alpn_protocol`"
 
 #: library/ssl.rst:2515
 msgid ":meth:`~SSLSocket.selected_npn_protocol`"
-msgstr ""
+msgstr ":meth:`~SSLSocket.selected_npn_protocol`"
 
 #: library/ssl.rst:2516
 msgid ":meth:`~SSLSocket.cipher`"
-msgstr ""
+msgstr ":meth:`~SSLSocket.cipher`"
 
 #: library/ssl.rst:2517
 msgid ":meth:`~SSLSocket.shared_ciphers`"
-msgstr ""
+msgstr ":meth:`~SSLSocket.shared_ciphers`"
 
 #: library/ssl.rst:2518
 msgid ":meth:`~SSLSocket.compression`"
-msgstr ""
+msgstr ":meth:`~SSLSocket.compression`"
 
 #: library/ssl.rst:2519
 msgid ":meth:`~SSLSocket.pending`"
-msgstr ""
+msgstr ":meth:`~SSLSocket.pending`"
 
 #: library/ssl.rst:2520
 msgid ":meth:`~SSLSocket.do_handshake`"
-msgstr ""
+msgstr ":meth:`~SSLSocket.do_handshake`"
 
 #: library/ssl.rst:2521
 msgid ":meth:`~SSLSocket.verify_client_post_handshake`"
-msgstr ""
+msgstr ":meth:`~SSLSocket.verify_client_post_handshake`"
 
 #: library/ssl.rst:2522
 msgid ":meth:`~SSLSocket.unwrap`"
-msgstr ""
+msgstr ":meth:`~SSLSocket.unwrap`"
 
 #: library/ssl.rst:2523
 msgid ":meth:`~SSLSocket.get_channel_binding`"
-msgstr ""
+msgstr ":meth:`~SSLSocket.get_channel_binding`"
 
 #: library/ssl.rst:2524
 msgid ":meth:`~SSLSocket.version`"
-msgstr ""
+msgstr ":meth:`~SSLSocket.version`"
 
 #: library/ssl.rst:2526
 msgid ""

--- a/library/statistics.po
+++ b/library/statistics.po
@@ -244,7 +244,7 @@ msgstr ""
 
 #: library/statistics.rst:79
 msgid ":func:`linear_regression`"
-msgstr ""
+msgstr ":func:`linear_regression`"
 
 #: library/statistics.rst:79
 msgid "Slope and intercept for simple linear regression."

--- a/library/stdtypes.po
+++ b/library/stdtypes.po
@@ -6882,179 +6882,179 @@ msgstr ""
 
 #: library/stdtypes.rst:4923
 msgid ":class:`tuple`"
-msgstr ""
+msgstr ":class:`tuple`"
 
 #: library/stdtypes.rst:4924
 msgid ":class:`list`"
-msgstr ""
+msgstr ":class:`list`"
 
 #: library/stdtypes.rst:4925
 msgid ":class:`dict`"
-msgstr ""
+msgstr ":class:`dict`"
 
 #: library/stdtypes.rst:4926
 msgid ":class:`set`"
-msgstr ""
+msgstr ":class:`set`"
 
 #: library/stdtypes.rst:4927
 msgid ":class:`frozenset`"
-msgstr ""
+msgstr ":class:`frozenset`"
 
 #: library/stdtypes.rst:4928
 msgid ":class:`type`"
-msgstr ""
+msgstr ":class:`type`"
 
 #: library/stdtypes.rst:4929
 msgid ":class:`collections.deque`"
-msgstr ""
+msgstr ":class:`collections.deque`"
 
 #: library/stdtypes.rst:4930
 msgid ":class:`collections.defaultdict`"
-msgstr ""
+msgstr ":class:`collections.defaultdict`"
 
 #: library/stdtypes.rst:4931
 msgid ":class:`collections.OrderedDict`"
-msgstr ""
+msgstr ":class:`collections.OrderedDict`"
 
 #: library/stdtypes.rst:4932
 msgid ":class:`collections.Counter`"
-msgstr ""
+msgstr ":class:`collections.Counter`"
 
 #: library/stdtypes.rst:4933
 msgid ":class:`collections.ChainMap`"
-msgstr ""
+msgstr ":class:`collections.ChainMap`"
 
 #: library/stdtypes.rst:4934
 msgid ":class:`collections.abc.Awaitable`"
-msgstr ""
+msgstr ":class:`collections.abc.Awaitable`"
 
 #: library/stdtypes.rst:4935
 msgid ":class:`collections.abc.Coroutine`"
-msgstr ""
+msgstr ":class:`collections.abc.Coroutine`"
 
 #: library/stdtypes.rst:4936
 msgid ":class:`collections.abc.AsyncIterable`"
-msgstr ""
+msgstr ":class:`collections.abc.AsyncIterable`"
 
 #: library/stdtypes.rst:4937
 msgid ":class:`collections.abc.AsyncIterator`"
-msgstr ""
+msgstr ":class:`collections.abc.AsyncIterator`"
 
 #: library/stdtypes.rst:4938
 msgid ":class:`collections.abc.AsyncGenerator`"
-msgstr ""
+msgstr ":class:`collections.abc.AsyncGenerator`"
 
 #: library/stdtypes.rst:4939
 msgid ":class:`collections.abc.Iterable`"
-msgstr ""
+msgstr ":class:`collections.abc.Iterable`"
 
 #: library/stdtypes.rst:4940
 msgid ":class:`collections.abc.Iterator`"
-msgstr ""
+msgstr ":class:`collections.abc.Iterator`"
 
 #: library/stdtypes.rst:4941
 msgid ":class:`collections.abc.Generator`"
-msgstr ""
+msgstr ":class:`collections.abc.Generator`"
 
 #: library/stdtypes.rst:4942
 msgid ":class:`collections.abc.Reversible`"
-msgstr ""
+msgstr ":class:`collections.abc.Reversible`"
 
 #: library/stdtypes.rst:4943
 msgid ":class:`collections.abc.Container`"
-msgstr ""
+msgstr ":class:`collections.abc.Container`"
 
 #: library/stdtypes.rst:4944
 msgid ":class:`collections.abc.Collection`"
-msgstr ""
+msgstr ":class:`collections.abc.Collection`"
 
 #: library/stdtypes.rst:4945
 msgid ":class:`collections.abc.Callable`"
-msgstr ""
+msgstr ":class:`collections.abc.Callable`"
 
 #: library/stdtypes.rst:4946
 msgid ":class:`collections.abc.Set`"
-msgstr ""
+msgstr ":class:`collections.abc.Set`"
 
 #: library/stdtypes.rst:4947
 msgid ":class:`collections.abc.MutableSet`"
-msgstr ""
+msgstr ":class:`collections.abc.MutableSet`"
 
 #: library/stdtypes.rst:4948
 msgid ":class:`collections.abc.Mapping`"
-msgstr ""
+msgstr ":class:`collections.abc.Mapping`"
 
 #: library/stdtypes.rst:4949
 msgid ":class:`collections.abc.MutableMapping`"
-msgstr ""
+msgstr ":class:`collections.abc.MutableMapping`"
 
 #: library/stdtypes.rst:4950
 msgid ":class:`collections.abc.Sequence`"
-msgstr ""
+msgstr ":class:`collections.abc.Sequence`"
 
 #: library/stdtypes.rst:4951
 msgid ":class:`collections.abc.MutableSequence`"
-msgstr ""
+msgstr ":class:`collections.abc.MutableSequence`"
 
 #: library/stdtypes.rst:4952
 msgid ":class:`collections.abc.ByteString`"
-msgstr ""
+msgstr ":class:`collections.abc.ByteString`"
 
 #: library/stdtypes.rst:4953
 msgid ":class:`collections.abc.MappingView`"
-msgstr ""
+msgstr ":class:`collections.abc.MappingView`"
 
 #: library/stdtypes.rst:4954
 msgid ":class:`collections.abc.KeysView`"
-msgstr ""
+msgstr ":class:`collections.abc.KeysView`"
 
 #: library/stdtypes.rst:4955
 msgid ":class:`collections.abc.ItemsView`"
-msgstr ""
+msgstr ":class:`collections.abc.ItemsView`"
 
 #: library/stdtypes.rst:4956
 msgid ":class:`collections.abc.ValuesView`"
-msgstr ""
+msgstr ":class:`collections.abc.ValuesView`"
 
 #: library/stdtypes.rst:4957
 msgid ":class:`contextlib.AbstractContextManager`"
-msgstr ""
+msgstr ":class:`contextlib.AbstractContextManager`"
 
 #: library/stdtypes.rst:4958
 msgid ":class:`contextlib.AbstractAsyncContextManager`"
-msgstr ""
+msgstr ":class:`contextlib.AbstractAsyncContextManager`"
 
 #: library/stdtypes.rst:4959
 msgid ":class:`dataclasses.Field`"
-msgstr ""
+msgstr ":class:`dataclasses.Field`"
 
 #: library/stdtypes.rst:4960
 msgid ":class:`functools.cached_property`"
-msgstr ""
+msgstr ":class:`functools.cached_property`"
 
 #: library/stdtypes.rst:4961
 msgid ":class:`functools.partialmethod`"
-msgstr ""
+msgstr ":class:`functools.partialmethod`"
 
 #: library/stdtypes.rst:4962
 msgid ":class:`os.PathLike`"
-msgstr ""
+msgstr ":class:`os.PathLike`"
 
 #: library/stdtypes.rst:4963
 msgid ":class:`queue.LifoQueue`"
-msgstr ""
+msgstr ":class:`queue.LifoQueue`"
 
 #: library/stdtypes.rst:4964
 msgid ":class:`queue.Queue`"
-msgstr ""
+msgstr ":class:`queue.Queue`"
 
 #: library/stdtypes.rst:4965
 msgid ":class:`queue.PriorityQueue`"
-msgstr ""
+msgstr ":class:`queue.PriorityQueue`"
 
 #: library/stdtypes.rst:4966
 msgid ":class:`queue.SimpleQueue`"
-msgstr ""
+msgstr ":class:`queue.SimpleQueue`"
 
 #: library/stdtypes.rst:4967
 msgid ":ref:`re.Pattern <re-objects>`"
@@ -7066,35 +7066,35 @@ msgstr ""
 
 #: library/stdtypes.rst:4969
 msgid ":class:`shelve.BsdDbShelf`"
-msgstr ""
+msgstr ":class:`shelve.BsdDbShelf`"
 
 #: library/stdtypes.rst:4970
 msgid ":class:`shelve.DbfilenameShelf`"
-msgstr ""
+msgstr ":class:`shelve.DbfilenameShelf`"
 
 #: library/stdtypes.rst:4971
 msgid ":class:`shelve.Shelf`"
-msgstr ""
+msgstr ":class:`shelve.Shelf`"
 
 #: library/stdtypes.rst:4972
 msgid ":class:`types.MappingProxyType`"
-msgstr ""
+msgstr ":class:`types.MappingProxyType`"
 
 #: library/stdtypes.rst:4973
 msgid ":class:`weakref.WeakKeyDictionary`"
-msgstr ""
+msgstr ":class:`weakref.WeakKeyDictionary`"
 
 #: library/stdtypes.rst:4974
 msgid ":class:`weakref.WeakMethod`"
-msgstr ""
+msgstr ":class:`weakref.WeakMethod`"
 
 #: library/stdtypes.rst:4975
 msgid ":class:`weakref.WeakSet`"
-msgstr ""
+msgstr ":class:`weakref.WeakSet`"
 
 #: library/stdtypes.rst:4976
 msgid ":class:`weakref.WeakValueDictionary`"
-msgstr ""
+msgstr ":class:`weakref.WeakValueDictionary`"
 
 #: library/stdtypes.rst:4981
 #, fuzzy

--- a/library/tkinter.dnd.po
+++ b/library/tkinter.dnd.po
@@ -106,4 +106,4 @@ msgstr ""
 
 #: library/tkinter.dnd.rst:64
 msgid ":ref:`Bindings-and-Events`"
-msgstr ""
+msgstr ":ref:`Bindings-and-Events`"

--- a/library/types.po
+++ b/library/types.po
@@ -97,7 +97,7 @@ msgstr ""
 
 #: library/types.rst:67
 msgid ":ref:`metaclasses`"
-msgstr ""
+msgstr ":ref:`metaclasses`"
 
 #: library/types.rst:67
 msgid "Full details of the class creation process supported by these functions"

--- a/whatsnew/2.7.po
+++ b/whatsnew/2.7.po
@@ -487,7 +487,7 @@ msgstr ""
 
 #: whatsnew/2.7.rst:442
 msgid ":ref:`upgrading-optparse-code`"
-msgstr ""
+msgstr ":ref:`upgrading-optparse-code`"
 
 #: whatsnew/2.7.rst:441
 msgid ""

--- a/whatsnew/3.7.po
+++ b/whatsnew/3.7.po
@@ -70,7 +70,7 @@ msgstr ""
 
 #: whatsnew/3.7.rst:70
 msgid ":ref:`whatsnew37_importlib_resources`"
-msgstr ""
+msgstr ":ref:`whatsnew37_importlib_resources`"
 
 #: whatsnew/3.7.rst:72
 msgid "New built-in features:"
@@ -478,27 +478,27 @@ msgstr ""
 
 #: whatsnew/3.7.rst:1447
 msgid ":func:`time.clock_gettime_ns`"
-msgstr ""
+msgstr ":func:`time.clock_gettime_ns`"
 
 #: whatsnew/3.7.rst:1448
 msgid ":func:`time.clock_settime_ns`"
-msgstr ""
+msgstr ":func:`time.clock_settime_ns`"
 
 #: whatsnew/3.7.rst:1449
 msgid ":func:`time.monotonic_ns`"
-msgstr ""
+msgstr ":func:`time.monotonic_ns`"
 
 #: whatsnew/3.7.rst:1450
 msgid ":func:`time.perf_counter_ns`"
-msgstr ""
+msgstr ":func:`time.perf_counter_ns`"
 
 #: whatsnew/3.7.rst:1451
 msgid ":func:`time.process_time_ns`"
-msgstr ""
+msgstr ":func:`time.process_time_ns`"
 
 #: whatsnew/3.7.rst:1452
 msgid ":func:`time.time_ns`"
-msgstr ""
+msgstr ":func:`time.time_ns`"
 
 #: whatsnew/3.7.rst:354
 msgid "The new functions return the number of nanoseconds as an integer value."


### PR DESCRIPTION
Based on comment: https://github.com/python/python-docs-fr/pull/1576#discussion_r875702152

```python
import re
from pathlib import Path

for path in Path.cwd().rglob("*.po"):
    # print(path)
    lines = path.read_text(encoding="utf-8").splitlines()
    modified = False
    for index, line in enumerate(lines):
        m = re.match(r'msgid "(:[a-z-]+:`[^`<]*?`)"', line)
        if m is not None:
            # print(m)
            if lines[index + 1].startswith('msgstr ""'):
                lines[index + 1] = f'msgstr "{m[1]}"'
                modified = True
    if modified:
        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
```