### PR TITLE
Reformulation dans glossary.po

### DIFF
--- a/glossary.po
+++ b/glossary.po
@@ -1255,8 +1255,8 @@ msgid ""
 "`483`, :pep:`484`, :pep:`585`, and the :mod:`typing` module."
 msgstr ""
 "Pour plus de détails, voir :ref:`types alias génériques <types-"
-"genericalias>`, ainsi que les PEP :pep:`483 <483>`, :pep:`484 <484>`, :pep:"
-"`585 <585>`, et le module :mod:`typing`."
+"genericalias>` et le module :mod:`typing`.  On trouvera l'historique de "
+"cette fonctionnalité dans la :pep:`483`, la :pep:`484` et la :pep:`585`."
 
 #: glossary.rst:530
 msgid "GIL"


### PR DESCRIPTION
Pour des raisons que je n'ai pas creusées, la syntaxe `` :pep:`quelque
chose <numéro>` `` est une extension de Sphinx, qui n'est pas présente
dans Docutils. Cela gêne pospell, qui dit « (ERROR/3) PEP number must
be a number from 0 to 9999; "585 <585>" is invalid. »