### PR TITLE
FIX: Turtle module constant should not be translated.

### DIFF
--- a/library/turtle.po
+++ b/library/turtle.po
@@ -6,7 +6,7 @@ msgstr ""
 "Project-Id-Version: Python 3\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-04-05 10:05+0200\n"
-"PO-Revision-Date: 2021-03-15 23:21+0100\n"
+"PO-Revision-Date: 2022-07-05 21:39+0200\n"
 "Last-Translator: Jules Lasne <jules.lasne@gmail.com>\n"
 "Language-Team: FRENCH <traductions@lists.afpy.org>\n"
 "Language: fr\n"
@@ -934,23 +934,23 @@ msgstr ""
 
 #: library/turtle.rst:617
 msgid "\"fastest\":  0"
-msgstr "« le plus rapide » : 0"
+msgstr "`\"fastest\"` :  0"
 
 #: library/turtle.rst:618
 msgid "\"fast\":  10"
-msgstr "« rapide » : 10"
+msgstr "`\"fast\"` :  10"
 
 #: library/turtle.rst:619
 msgid "\"normal\":  6"
-msgstr "« vitesse normale » : 6"
+msgstr "`\"normal\"` :  6"
 
 #: library/turtle.rst:620
 msgid "\"slow\":  3"
-msgstr "« lent » : 3"
+msgstr "`\"slow\"` :  3"
 
 #: library/turtle.rst:621
 msgid "\"slowest\":  1"
-msgstr "« le plus lent » : 1"
+msgstr "`\"slowest\"` :  1"
 
 #: library/turtle.rst:623
 msgid ""


### PR DESCRIPTION
Car en fait ça s'utilise à coup de `turtle.speed("fastest")` donc il faut garder `"fastest"` dans la doc.