### PR TITLE
Traduction de library/asyncio-future.po

### DIFF
--- a/library/asyncio-future.po
+++ b/library/asyncio-future.po
@@ -6,59 +6,70 @@ msgstr ""
 "Project-Id-Version: Python 3\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-03-18 17:06+0100\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"PO-Revision-Date: 2022-08-22 22:57-0400\n"
+"Last-Translator: Nicolas Haller <nicolas@haller.im>\n"
 "Language-Team: FRENCH <traductions@lists.afpy.org>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.1.1\n"
 
 #: library/asyncio-future.rst:8
 msgid "Futures"
-msgstr "Futurs"
+msgstr "Futures"
 
 #: library/asyncio-future.rst:10
 msgid ""
 "**Source code:** :source:`Lib/asyncio/futures.py`, :source:`Lib/asyncio/"
 "base_futures.py`"
 msgstr ""
+"**Code source :** :source:`Lib/asyncio/futures.py`, :source:`Lib/asyncio/"
+"base_futures.py`"
 
 #: library/asyncio-future.rst:15
 msgid ""
 "*Future* objects are used to bridge **low-level callback-based code** with "
 "high-level async/await code."
 msgstr ""
+"Les objets *Future* sont utilisés comme passerelles entre du **code bas "
+"niveau basé sur des fonctions de rappel** et du code haut niveau utilisant "
+"*async* et *await*."
 
 #: library/asyncio-future.rst:20
 msgid "Future Functions"
-msgstr ""
+msgstr "Fonctions pour *Future*"
 
 #: library/asyncio-future.rst:24
 msgid "Return ``True`` if *obj* is either of:"
-msgstr ""
+msgstr "Renvoie ``True`` si *obj* est soit :"
 
 #: library/asyncio-future.rst:26
 msgid "an instance of :class:`asyncio.Future`,"
-msgstr ""
+msgstr "une instance de :class:`asyncio.Future` ;"
 
 #: library/asyncio-future.rst:27
 msgid "an instance of :class:`asyncio.Task`,"
-msgstr ""
+msgstr "une instance de :class:`asyncio.Task` ;"
 
 #: library/asyncio-future.rst:28
 msgid "a Future-like object with a ``_asyncio_future_blocking`` attribute."
 msgstr ""
+"un objet se comportant comme *Future* et possédant un attribut "
+"``_asyncio_future_blocking``."
 
 #: library/asyncio-future.rst:36
 msgid "Return:"
-msgstr ""
+msgstr "Renvoie :"
 
 #: library/asyncio-future.rst:38
 msgid ""
 "*obj* argument as is, if *obj* is a :class:`Future`, a :class:`Task`, or a "
 "Future-like object (:func:`isfuture` is used for the test.)"
 msgstr ""
+"l'objet *obj* tel quel si c'est un objet de type :class:`Future`, :class:"
+"`Task` ou se comportant comme un *Future*. :func:`isfuture` est utilisée "
+"pour le test ;"
 
 #: library/asyncio-future.rst:42
 msgid ""
@@ -66,28 +77,40 @@ msgid ""
 "`iscoroutine` is used for the test); in this case the coroutine will be "
 "scheduled by ``ensure_future()``."
 msgstr ""
+"un objet de type :class:`Task` encapsulant *obj* si ce dernier est une "
+"coroutine (:func:`iscoroutine` est utilisée pour le test). Dans ce cas, "
+"l’exécution de la coroutine sera planifiée par ``ensure_future()`` ;"
 
 #: library/asyncio-future.rst:47
 msgid ""
 "a :class:`Task` object that would await on *obj*, if *obj* is an awaitable (:"
 "func:`inspect.isawaitable` is used for the test.)"
 msgstr ""
+"un objet de type :class:`Task` qui attendra (*await*) sur *obj* si ce "
+"dernier peut être attendu (*awaitable*). :func:`iscoroutine` est utilisée "
+"pour le test."
 
 #: library/asyncio-future.rst:50
 msgid "If *obj* is neither of the above a :exc:`TypeError` is raised."
 msgstr ""
+"Si *obj* ne correspond à aucun des critères ci-dessus, une exception :exc:"
+"`TypeError` est levée."
 
 #: library/asyncio-future.rst:54
 msgid ""
 "See also the :func:`create_task` function which is the preferred way for "
 "creating new Tasks."
 msgstr ""
+"Voir aussi la fonction :func:`create_task` qui est la manière privilégiée "
+"pour créer des nouvelles tâches."
 
 #: library/asyncio-future.rst:57
 msgid ""
 "Save a reference to the result of this function, to avoid a task "
 "disappearing mid execution."
 msgstr ""
+"Gardez une référence au résultat de cette fonction pour éviter de voir une "
+"tâche disparaitre au milieu de son exécution."
 
 #: library/asyncio-future.rst:60
 msgid "The function accepts any :term:`awaitable` object."
@@ -98,28 +121,38 @@ msgid ""
 "Deprecation warning is emitted if *obj* is not a Future-like object and "
 "*loop* is not specified and there is no running event loop."
 msgstr ""
+"Un ``DeprecationWarning`` est levé si *obj* n'est pas un objet se comportant "
+"comme un *Future*, si *loop* n'est pas spécifié et s'il n'y a pas de boucle "
+"d'évènements en cours d'exécution."
 
 #: library/asyncio-future.rst:70
 msgid ""
 "Wrap a :class:`concurrent.futures.Future` object in a :class:`asyncio."
 "Future` object."
 msgstr ""
+"Encapsule un objet :class:`concurrent.futures.Future` dans un objet :class:"
+"`asyncio.Future`."
 
 #: library/asyncio-future.rst:73
 msgid ""
 "Deprecation warning is emitted if *future* is not a Future-like object and "
 "*loop* is not specified and there is no running event loop."
 msgstr ""
+"Un ``DeprecationWarning`` est levé si *future* n'est pas un objet se "
+"comportant comme un *Future*, si *loop* n'est pas spécifié et s'il n'y a pas "
+"de boucle d'évènements en cours d'exécution."
 
 #: library/asyncio-future.rst:79
 msgid "Future Object"
-msgstr ""
+msgstr "Objet *Future*"
 
 #: library/asyncio-future.rst:83
 msgid ""
 "A Future represents an eventual result of an asynchronous operation.  Not "
 "thread-safe."
 msgstr ""
+"Un *Future* représente le résultat final d'une opération asynchrone. N'est "
+"pas conçu pour être exécuté dans un contexte multi-fils."
 
 #: library/asyncio-future.rst:86
 msgid ""
@@ -127,6 +160,9 @@ msgid ""
 "objects until they either have a result or an exception set, or until they "
 "are cancelled."
 msgstr ""
+"*Future* est un objet qui peut être attendu (:term:`awaitable`). Les "
+"coroutines peuvent attendre les objets *Future* jusqu'à ce qu'ils retournent "
+"un résultat, un jeu d'exceptions ou qu'ils soient annulés."
 
 #: library/asyncio-future.rst:90
 msgid ""
@@ -134,6 +170,10 @@ msgid ""
 "protocols implemented using asyncio :ref:`transports <asyncio-transports-"
 "protocols>`) to interoperate with high-level async/await code."
 msgstr ""
+"Les *Futures* sont habituellement utilisés pour permettre à du code bas "
+"niveau basé sur des fonctions de rappel (par exemple : les protocoles "
+"utilisant *asyncio* :ref:`transports <asyncio-transports-protocols>`) "
+"d'interagir avec du code haut niveau utilisant *async* et *await*."
 
 #: library/asyncio-future.rst:95
 msgid ""
@@ -142,6 +182,11 @@ msgid ""
 "create_future`.  This way alternative event loop implementations can inject "
 "their own optimized implementations of a Future object."
 msgstr ""
+"Une bonne règle empirique est de ne jamais exposer des objets *Future* dans "
+"des *API* destinées à l'utilisateur. La façon privilégiée de créer des "
+"objets *Future* est d'appeler la méthode :meth:`loop.create_future`. Cela "
+"permet aux implémentations alternatives de la boucle d'évènements d'utiliser "
+"leur propre implémentation de l'objet *Future*."
 
 #: library/asyncio-future.rst:101
 msgid "Added support for the :mod:`contextvars` module."
@@ -152,34 +197,38 @@ msgid ""
 "Deprecation warning is emitted if *loop* is not specified and there is no "
 "running event loop."
 msgstr ""
+"Un ``DeprecationWarning`` est levé si *loop* n'est pas spécifié et s'il n'y "
+"a pas de boucle d'évènements en cours d'exécution."
 
 #: library/asyncio-future.rst:110
 msgid "Return the result of the Future."
-msgstr ""
+msgstr "Renvoie le résultat du *Future*."
 
 #: library/asyncio-future.rst:112
 msgid ""
 "If the Future is *done* and has a result set by the :meth:`set_result` "
 "method, the result value is returned."
 msgstr ""
+"Si le *Future* est « terminé » et a un résultat défini par la méthode :meth:"
+"`set_result`, ce résultat est renvoyé."
 
 #: library/asyncio-future.rst:115
 msgid ""
 "If the Future is *done* and has an exception set by the :meth:"
 "`set_exception` method, this method raises the exception."
 msgstr ""
+"Si le *Future* est « terminé » et a une exception définie par la méthode :"
+"meth:`set_exception`, cette méthode lève l'exception."
 
 #: library/asyncio-future.rst:206
-#, fuzzy
 msgid ""
 "If the Future has been *cancelled*, this method raises a :exc:"
 "`CancelledError` exception."
 msgstr ""
-"Si la tâche a été *annulée*, cette méthode lève une exception  :exc:"
+"Si la tâche a été *annulée*, cette méthode lève une exception :exc:"
 "`CancelledError`."
 
 #: library/asyncio-future.rst:121
-#, fuzzy
 msgid ""
 "If the Future's result isn't yet available, this method raises a :exc:"
 "`InvalidStateError` exception."
@@ -188,53 +237,62 @@ msgstr ""
 "une exception :exc:`InvalidStateError`."
 
 #: library/asyncio-future.rst:126
-#, fuzzy
 msgid "Mark the Future as *done* and set its result."
-msgstr "Marque le futur comme terminé et définit son résultat."
+msgstr "Marque le *Future* comme « terminé » et définit son résultat."
 
 #: library/asyncio-future.rst:135
 msgid ""
 "Raises a :exc:`InvalidStateError` error if the Future is already *done*."
 msgstr ""
+"Lève une erreur :exc:`InvalidStateError` si le *Future* est déjà « terminé »."
 
 #: library/asyncio-future.rst:133
-#, fuzzy
 msgid "Mark the Future as *done* and set an exception."
-msgstr "Marque le futur comme terminé et définit une exception."
+msgstr "Marque le *Future* comme « terminé » et définit une exception."
 
 #: library/asyncio-future.rst:140
 msgid "Return ``True`` if the Future is *done*."
-msgstr ""
+msgstr "Renvoie ``True`` si le *Future* est « terminé »."
 
 #: library/asyncio-future.rst:142
 msgid ""
 "A Future is *done* if it was *cancelled* or if it has a result or an "
 "exception set with :meth:`set_result` or :meth:`set_exception` calls."
 msgstr ""
+"Un *Future* est « terminé » s'il a été « annulé » ou si un résultat ou un "
+"jeu d'exception a été défini par les méthodes :meth:`set_result` ou :meth:"
+"`set_exception`."
 
 #: library/asyncio-future.rst:148
 msgid "Return ``True`` if the Future was *cancelled*."
-msgstr ""
+msgstr "Renvoie ``True`` si le *Future* a été « annulé »."
 
 #: library/asyncio-future.rst:150
 msgid ""
 "The method is usually used to check if a Future is not *cancelled* before "
 "setting a result or an exception for it::"
 msgstr ""
+"Cette méthode est habituellement utilisée pour vérifier qu'un *Future* n'est "
+"pas « annulé » avant de définir un résultat ou une exception pour celui-ci ::"
 
 #: library/asyncio-future.rst:158
 msgid "Add a callback to be run when the Future is *done*."
 msgstr ""
+"Ajoute une fonction de rappel à exécuter lorsque le *Future* est « terminé »."
 
 #: library/asyncio-future.rst:160
 msgid "The *callback* is called with the Future object as its only argument."
 msgstr ""
+"L'argument *callback* est appelé avec l'objet *Future* comme seul argument."
 
 #: library/asyncio-future.rst:163
 msgid ""
 "If the Future is already *done* when this method is called, the callback is "
 "scheduled with :meth:`loop.call_soon`."
 msgstr ""
+"Si le *Future* est déjà « terminé » lorsque la méthode est appelée, "
+"l'exécution de la fonction de rappel est planifiée avec :meth:`loop."
+"call_soon`."
 
 #: library/asyncio-future.rst:166
 msgid ""
@@ -242,18 +300,24 @@ msgid ""
 "class:`contextvars.Context` for the *callback* to run in. The current "
 "context is used when no *context* is provided."
 msgstr ""
+"L'argument nommé optionnel *context* permet de spécifier une classe :class:"
+"`contextvars.Context` personnalisée dans laquelle la fonction de rappel "
+"s’exécutera. Le contexte actuel est utilisé si *context* n'est pas fourni."
 
 #: library/asyncio-future.rst:170
 msgid ""
 ":func:`functools.partial` can be used to pass parameters to the callback, e."
 "g.::"
 msgstr ""
+":func:`functools.partial` peut être utilisée pour passer des paramètres à la "
+"fonction de rappel ::"
 
 #: library/asyncio-future.rst:177
 msgid ""
 "The *context* keyword-only parameter was added. See :pep:`567` for more "
 "details."
 msgstr ""
+"Ajout de l'argument nommé *context*. Voir :pep:`567` pour plus de détails."
 
 #: library/asyncio-future.rst:183
 msgid "Remove *callback* from the callbacks list."
@@ -264,10 +328,12 @@ msgid ""
 "Returns the number of callbacks removed, which is typically 1, unless a "
 "callback was added more than once."
 msgstr ""
+"Renvoie le nombre de fonctions de rappel retiré. La méthode renvoie "
+"généralement 1, à moins que la fonction ait été ajoutée plus d'une fois."
 
 #: library/asyncio-future.rst:190
 msgid "Cancel the Future and schedule callbacks."
-msgstr ""
+msgstr "Annule le *Future* et planifie l'exécution des fonctions de rappel."
 
 #: library/asyncio-future.rst:192
 msgid ""
@@ -275,78 +341,101 @@ msgid ""
 "change the Future's state to *cancelled*, schedule the callbacks, and return "
 "``True``."
 msgstr ""
+"Si le *Future* est déjà « terminé » ou « annulé », renvoie ``False``. "
+"Autrement, change l'état du *Future* à « annulé », planifie l'exécution des "
+"fonctions de rappel et renvoie ``True``."
 
 #: library/asyncio-future.rst:196
 msgid "Added the *msg* parameter."
-msgstr ""
+msgstr "Ajout du paramètre *msg*."
 
 #: library/asyncio-future.rst:201
 msgid "Return the exception that was set on this Future."
-msgstr ""
+msgstr "Renvoie l'exception définit pour ce *Future*."
 
 #: library/asyncio-future.rst:203
 msgid ""
 "The exception (or ``None`` if no exception was set) is returned only if the "
 "Future is *done*."
 msgstr ""
+"L'exception, ou ``None`` si aucune exception n'a été défini, est renvoyé "
+"seulement si le *Future* est « terminé »."
 
 #: library/asyncio-future.rst:209
-#, fuzzy
 msgid ""
 "If the Future isn't *done* yet, this method raises an :exc:"
 "`InvalidStateError` exception."
 msgstr ""
-"Si la tâche n'est pas encore *achevée*, cette méthode lève une exception :"
-"exc:`InvalidStateError`."
+"Si le *Future* n'est pas encore « terminé », cette méthode lève une "
+"exception :exc:`InvalidStateError`."
 
 #: library/asyncio-future.rst:214
 msgid "Return the event loop the Future object is bound to."
-msgstr ""
+msgstr "Renvoie la boucle d'évènements à laquelle le *Future* est attaché."
 
 #: library/asyncio-future.rst:221
 msgid ""
 "This example creates a Future object, creates and schedules an asynchronous "
 "Task to set result for the Future, and waits until the Future has a result::"
 msgstr ""
+"Cet exemple crée un objet *Future*, puis crée et planifie l’exécution d'une "
+"tâche asynchrone qui définira le résultat du *Future* et attend jusqu'à ce "
+"que le *Future* ait un résultat ::"
 
 #: library/asyncio-future.rst:256
 msgid ""
 "The Future object was designed to mimic :class:`concurrent.futures.Future`.  "
 "Key differences include:"
 msgstr ""
+"L'objet *Future* est conçu pour imiter la classe :class:`concurrent.futures."
+"Future`. Les principales différences sont :"
 
 #: library/asyncio-future.rst:259
 msgid ""
 "unlike asyncio Futures, :class:`concurrent.futures.Future` instances cannot "
 "be awaited."
 msgstr ""
+"contrairement au *Future asyncio*, les instances de :class:`concurrent."
+"futures.Future` ne peuvent être attendues ;"
 
 #: library/asyncio-future.rst:262
 msgid ""
 ":meth:`asyncio.Future.result` and :meth:`asyncio.Future.exception` do not "
 "accept the *timeout* argument."
 msgstr ""
+":meth:`asyncio.Future.result` et :meth:`asyncio.Future.exception` "
+"n'acceptent pas d'argument *timeout* ;"
 
 #: library/asyncio-future.rst:265
 msgid ""
 ":meth:`asyncio.Future.result` and :meth:`asyncio.Future.exception` raise an :"
 "exc:`InvalidStateError` exception when the Future is not *done*."
 msgstr ""
+":meth:`asyncio.Future.result` et :meth:`asyncio.Future.exception` lèvent une "
+"exception :exc:`InvalidStateError` lorsque le *Future* n'est pas "
+"« terminé » ;"
 
 #: library/asyncio-future.rst:269
 msgid ""
 "Callbacks registered with :meth:`asyncio.Future.add_done_callback` are not "
 "called immediately.  They are scheduled with :meth:`loop.call_soon` instead."
 msgstr ""
+"les fonctions de rappel enregistrées à l'aide de :meth:`asyncio.Future."
+"add_done_callback` ne sont pas exécutées immédiatement mais planifiées avec :"
+"meth:`loop.call_soon` ;"
 
 #: library/asyncio-future.rst:273
 msgid ""
 "asyncio Future is not compatible with the :func:`concurrent.futures.wait` "
 "and :func:`concurrent.futures.as_completed` functions."
 msgstr ""
+"les *Future asyncio* ne sont pas compatibles avec les fonctions :func:"
+"`concurrent.futures.wait` et :func:`concurrent.futures.as_completed` ;"
 
 #: library/asyncio-future.rst:277
 msgid ""
 ":meth:`asyncio.Future.cancel` accepts an optional ``msg`` argument, but :"
 "func:`concurrent.futures.cancel` does not."
 msgstr ""
+":meth:`asyncio.Future.cancel` accepte un argument optionnel ``msg`` mais "
+"pas :func:`concurrent.futures.cancel`."


### PR DESCRIPTION
Voici ma traduction pour asyncio future.
J'ai pris le parti de ne pas traduire Future et de le placer en italique mais c'est sujet à discussion.

Closes #1903 