### PR TITLE
Drop powrap from make verifs. Closes #1841.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,6 @@ fuzzy: ensure_prerequisites
 
 .PHONY: verifs
 verifs: spell
-	powrap --check --quiet *.po */*.po
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Keep It Simple, de toute façons la CI de github passera le awk pour vérifier la longueur des lignes.