### PR TITLE
màj: utilisation de htmlserve au lieu de serve dans le Makefile

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -315,7 +315,7 @@ documentation local :
 
 .. code-block:: bash
 
-    make serve
+    make htmlview
 
 
 La documentation est publiée à l'adresse `<http://localhost:8000/library/sys.html>`_.
@@ -329,7 +329,7 @@ nécessaire.
 Poedit donne beaucoup d'avertissements, par exemple pour vous informer que
 « la traduction devrait commencer par une majuscule » car c'est le cas pour
 la source. Ces avertissements ne sont pas tous fondés. En cas de doute,
-*affichez et relisez la page HTML produite* avec ``make serve``.
+*affichez et relisez la page HTML produite* avec ``make htmlview``.
 
 Quatrième étape : publier sa traduction
 =======================================

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ all: ensure_prerequisites
 	  -D latex_elements.inputenc=       \
 	  -D latex_elements.fontenc='       \
 	  $(MODE)
-	@echo "Build success, open file://$(abspath venv/cpython/)/Doc/build/html/index.html or run 'make serve' to see them."
+	@echo "Build success, open file://$(abspath venv/cpython/)/Doc/build/html/index.html or run 'make htmlview' to see them."
 
 
 # We clone cpython/ inside venv/ because venv/ is the only directory
@@ -116,15 +116,6 @@ ensure_prerequisites: venv/cpython/.git/HEAD
 	    echo "  python -m pip install -r requirements.txt -r venv/cpython/Doc/requirements.txt"; \
 	    exit 1; \
 	fi
-
-
-.PHONY: serve
-serve:
-ifdef SERVE_PORT
-	$(MAKE) -C venv/cpython/Doc/ serve SERVE_PORT=$(SERVE_PORT)
-else
-	$(MAKE) -C venv/cpython/Doc/ serve
-endif
 
 .PHONY: htmlview
 htmlview: MODE=htmlview

--- a/Makefile
+++ b/Makefile
@@ -121,9 +121,9 @@ ensure_prerequisites: venv/cpython/.git/HEAD
 .PHONY: serve
 serve:
 ifdef SERVE_PORT
-	$(MAKE) -C venv/cpython/Doc/ serve SERVE_PORT=$(SERVE_PORT)
+	$(MAKE) -C venv/cpython/Doc/ htmlview SERVE_PORT=$(SERVE_PORT)
 else
-	$(MAKE) -C venv/cpython/Doc/ serve
+	$(MAKE) -C venv/cpython/Doc/ htmlview
 endif
 
 .PHONY: todo

--- a/Makefile
+++ b/Makefile
@@ -121,10 +121,14 @@ ensure_prerequisites: venv/cpython/.git/HEAD
 .PHONY: serve
 serve:
 ifdef SERVE_PORT
-	$(MAKE) -C venv/cpython/Doc/ htmlview SERVE_PORT=$(SERVE_PORT)
+	$(MAKE) -C venv/cpython/Doc/ serve SERVE_PORT=$(SERVE_PORT)
 else
-	$(MAKE) -C venv/cpython/Doc/ htmlview
+	$(MAKE) -C venv/cpython/Doc/ serve
 endif
+
+.PHONY: htmlview
+htmlview: MODE=htmlview
+htmlview: all
 
 .PHONY: todo
 todo: ensure_prerequisites


### PR DESCRIPTION
En lien avec #1918 .

Je ne suis pas 100% convaincue que c'est la façon de faire ce changement... Suggestions (et explications) bienvenues.

Avec `make htmlview`, je réussi à générer la doc localement mais je ne vois pas comment accéder à la version traduite... j'ai regardé sur d'autres repos de doc python - [exemple](https://github.com/python/python-docs-es/blob/dfe5e62a1f23d8bc549c601b3903817a46a448bc/Makefile#L82) - et je ne vois pas trop ce que je dois changer.

C'est probablement pas le moment de faire ce changement - je vous laisse en juger :) 