### PR TITLE
Use double backticks for RST

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,5 +6,5 @@ Ce repo existe sur deux forges :
 - https://git.afpy.org/AFPy/python-docs-fr/
 - https://github.com/python/python-docs-fr/
 
-le travail s’effectue sur `git.afpy.org`, github est un mirroir
+le travail s’effectue sur ``git.afpy.org``, github est un mirroir
 utilisé pour générer la doc sur https://docs.python.org/fr/


### PR DESCRIPTION
Fixes a Sphinx Lint CI failure:

> /home/runner/work/sphinx-lint/sphinx-lint/tests/fixtures/friends/python-docs-fr/README.rst:9: default role used (hint: for inline literals, use double backticks) (default-role)



https://github.com/sphinx-contrib/sphinx-lint/actions/runs/12726193605/job/35474290994#step:6:56